### PR TITLE
Overlay improvements: region-sized window, annotations, microphone, audio indicator

### DIFF
--- a/docs/plans/06-pill-buttons-blocked-by-overlay.md
+++ b/docs/plans/06-pill-buttons-blocked-by-overlay.md
@@ -1,5 +1,12 @@
 # Plan 06 — Fix: Pill Buttons Blocked by Active Overlay Tool
 
+> **Status**: ✅ Resolved by Plan 04 on 2026-04-19. The region-sized overlay
+> (commit `a55459e`) no longer covers the recording pill's screen area for
+> typical recordings, so the overlay's interactive state no longer blocks
+> clicks on pill buttons. The only remaining case is when the recording
+> region explicitly overlaps the pill position (top-center, y≈10); this
+> edge case is acceptable for now.
+
 ## Context
 
 **Bug observation**: When a drawing tool (rectangle or arrow) is active on the overlay, the recording pill's toolbar buttons (switch tool, clear, webcam, cycle position, stop recording) can't be clicked. The user can still use keyboard shortcuts (`Ctrl+Shift+R/A/Z/W/E`) but not the visible buttons in the pill.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -13,14 +13,14 @@ Sequenced plan documents for remaining overlay work. Each plan is self-contained
 3. [03 — Microphone Audio Recording](./03-microphone-audio-recording.md) ✅ (SYS deferred)
    Separate mic + system audio toggles, device selection, FFmpeg mixing. MIC shipped with live audio level indicator. SYS deferred to a future release.
 
-4. [04 — Phase 6: Region-Sized Overlay + DPI + Multi-Monitor](./04-phase-6-region-sizing-and-dpi.md)
-   Replace fullscreen overlay with region-sized window. Fixes DPI issues and the latent gdigrab bug. Revisits Plans 01 and 02 to adapt to the new coordinate system.
+4. [04 — Phase 6: Region-Sized Overlay + DPI + Multi-Monitor](./04-phase-6-region-sizing-and-dpi.md) ✅ (core)
+   Region-sized overlay + outline + transparency-during-drawing shipped. DPI scaling, gdigrab DPI fix, ripple cap, and multi-monitor testing still pending (low priority at 100% DPI single-monitor).
 
 5. [05 — Timeout Investigation](./05-timeout-investigation.md) ✅ (no app bug)
    Research task. Root cause was Claude Code's Monitor tool, not the SnippingZo app. No code change required.
 
-6. [06 — Fix: Pill Buttons Blocked by Active Overlay Tool](./06-pill-buttons-blocked-by-overlay.md)
-   Known bug — pill buttons can't be clicked while a drawing tool is active. Floating toolbar on overlay as primary fix. Do last; Phase 6 (Plan 04) may partially resolve it.
+6. [06 — Fix: Pill Buttons Blocked by Active Overlay Tool](./06-pill-buttons-blocked-by-overlay.md) ✅ (resolved by Plan 04)
+   Auto-fixed — region-sized overlay no longer covers the recording pill area for typical recordings.
 
 7. [07 — Context-Aware `Ctrl+Shift+S` (Screenshot / Stop Recording)](./07-stop-recording-hotkey.md) ✅
    Reuses the existing capture shortcut as a state-dependent toggle: takes a screenshot when idle, stops the recording when one is active. Provides keyboard escape for the Plan 06 blocking bug.

--- a/src-tauri/src/commands/overlay.rs
+++ b/src-tauri/src/commands/overlay.rs
@@ -1,7 +1,9 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::Mutex;
-use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{
+    AppHandle, Emitter, Manager, PhysicalPosition, PhysicalSize, WebviewUrl, WebviewWindowBuilder,
+};
 
 #[cfg(windows)]
 use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
@@ -51,6 +53,40 @@ unsafe extern "system" fn mouse_proc(n_code: i32, w_param: WPARAM, l_param: LPAR
 
 // ─── Overlay window commands ───
 
+/// Applies a fully transparent background to the overlay's WebView2 surface
+/// via the COREWEBVIEW2_DEFAULT_BACKGROUND_COLOR COM API. Must be called
+/// whenever the window's layered-transparency state may have been reset
+/// (e.g. after resize or after toggling set_ignore_cursor_events on Windows,
+/// which can cause the webview to fall back to an opaque default background).
+#[cfg(windows)]
+fn apply_webview_transparency(
+    overlay: &tauri::WebviewWindow,
+) -> Result<(), tauri::Error> {
+    overlay.with_webview(|webview: tauri::webview::PlatformWebview| {
+        unsafe {
+            use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2Controller2;
+            use windows::core::Interface;
+
+            let controller = webview.controller();
+            let controller2: ICoreWebView2Controller2 = controller
+                .cast()
+                .expect("Failed to get ICoreWebView2Controller2");
+
+            let transparent_color =
+                webview2_com::Microsoft::Web::WebView2::Win32::COREWEBVIEW2_COLOR {
+                    A: 0,
+                    R: 0,
+                    G: 0,
+                    B: 0,
+                };
+            controller2
+                .SetDefaultBackgroundColor(transparent_color)
+                .expect("Failed to set transparent background");
+        }
+    })
+}
+
+
 #[tauri::command]
 pub async fn show_overlay(
     app: AppHandle,
@@ -65,14 +101,50 @@ pub async fn show_overlay(
         return Ok(());
     }
 
-    // Build overlay URL with region query params so the React app knows the recording area
+    // Compute the outline pad on each side. We expand the overlay window by
+    // OUTLINE_PAD pixels beyond the recording region (where screen space allows)
+    // so the region-outline border sits outside the capture. If the region
+    // touches the monitor edge on any side, pad on that side is 0 and the
+    // outline on that side falls back to being inside the recording.
+    const OUTLINE_PAD: i32 = 2;
+    let region_x = x.unwrap_or(0);
+    let region_y = y.unwrap_or(0);
+    let region_w = width.unwrap_or(1920).max(1);
+    let region_h = height.unwrap_or(1080).max(1);
+
+    // Query monitor bounds so we know where the screen edges are. Falls back
+    // to primary-resolution defaults if the query fails.
+    let (mon_x, mon_y, mon_w, mon_h) = app
+        .primary_monitor()
+        .ok()
+        .flatten()
+        .map(|m| {
+            let pos = m.position();
+            let sz = m.size();
+            (pos.x, pos.y, sz.width as i32, sz.height as i32)
+        })
+        .unwrap_or((0, 0, 1920, 1080));
+
+    let pad_left = if region_x - mon_x >= OUTLINE_PAD { OUTLINE_PAD } else { 0 };
+    let pad_top = if region_y - mon_y >= OUTLINE_PAD { OUTLINE_PAD } else { 0 };
+    let pad_right = if (mon_x + mon_w) - (region_x + region_w) >= OUTLINE_PAD {
+        OUTLINE_PAD
+    } else {
+        0
+    };
+    let pad_bottom = if (mon_y + mon_h) - (region_y + region_h) >= OUTLINE_PAD {
+        OUTLINE_PAD
+    } else {
+        0
+    };
+
+    // Build overlay URL. Frontend reads region + pad values to correctly size
+    // the region outline (inner edge aligned with the recorded region boundary).
     let url = format!(
-        "overlay.html?x={}&y={}&w={}&h={}",
-        x.unwrap_or(0),
-        y.unwrap_or(0),
-        width.unwrap_or(1920),
-        height.unwrap_or(1080),
+        "overlay.html?x={}&y={}&w={}&h={}&pl={}&pt={}&pr={}&pb={}",
+        region_x, region_y, region_w, region_h, pad_left, pad_top, pad_right, pad_bottom,
     );
+
 
     // Create the overlay window on the main thread via channel to avoid deadlocks.
     let (tx, rx) = mpsc::channel();
@@ -86,6 +158,11 @@ pub async fn show_overlay(
         )
         .title("")
         .decorations(false)
+        // Builder-level transparent(true) ensures the OS window is created with
+        // WS_EX_LAYERED, which is required for transparency to survive
+        // set_ignore_cursor_events toggles. The WebView2 COM DefaultBackgroundColor
+        // call below handles the webview's own background.
+        .transparent(true)
         .always_on_top(true)
         .skip_taskbar(true)
         .resizable(false)
@@ -101,37 +178,46 @@ pub async fn show_overlay(
         .map_err(|e| e.to_string())?
         .map_err(|e: tauri::Error| e.to_string())?;
 
-    // Set WebView2 background to fully transparent via COM API
-    #[cfg(windows)]
-    {
-        overlay
-            .with_webview(|webview: tauri::webview::PlatformWebview| {
-                unsafe {
-                    use webview2_com::Microsoft::Web::WebView2::Win32::ICoreWebView2Controller2;
-                    use windows::core::Interface;
-
-                    let controller = webview.controller();
-                    let controller2: ICoreWebView2Controller2 =
-                        controller.cast().expect("Failed to get ICoreWebView2Controller2");
-
-                    let transparent_color =
-                        webview2_com::Microsoft::Web::WebView2::Win32::COREWEBVIEW2_COLOR {
-                            A: 0,
-                            R: 0,
-                            G: 0,
-                            B: 0,
-                        };
-                    controller2
-                        .SetDefaultBackgroundColor(transparent_color)
-                        .expect("Failed to set transparent background");
-                }
-            })
-            .map_err(|e: tauri::Error| e.to_string())?;
-    }
+    // Size overlay to match the (padded) recording region in physical pixels.
+    // gdigrab + mouse hook both use physical coords, so PhysicalPosition/Size
+    // keeps the coordinate contract consistent end-to-end. Must be applied
+    // BEFORE the WebView2 transparency COM call; a resize afterwards reverts it.
+    let win_x = region_x - pad_left;
+    let win_y = region_y - pad_top;
+    let win_w = (region_w + pad_left + pad_right).max(1) as u32;
+    let win_h = (region_h + pad_top + pad_bottom).max(1) as u32;
 
     overlay
-        .set_fullscreen(true)
+        .set_position(PhysicalPosition::new(win_x, win_y))
         .map_err(|e: tauri::Error| e.to_string())?;
+    overlay
+        .set_size(PhysicalSize::new(win_w, win_h))
+        .map_err(|e: tauri::Error| e.to_string())?;
+
+    // Windows adds invisible chrome around frameless Tauri/wry windows
+    // (typically 8px on left/right/bottom, 0 on top). set_position sets the
+    // OUTER position, but WebView2 renders inside the INNER area. Without
+    // compensation, the inner area is offset by the chrome amount, which
+    // pushes the region outline inside the captured region on the affected
+    // sides. Query the delta and re-position the outer window so the inner
+    // area lands exactly where we want it.
+    if let (Ok(outer_pos), Ok(inner_pos)) =
+        (overlay.outer_position(), overlay.inner_position())
+    {
+        let dx = inner_pos.x - outer_pos.x;
+        let dy = inner_pos.y - outer_pos.y;
+        if dx != 0 || dy != 0 {
+            overlay
+                .set_position(PhysicalPosition::new(win_x - dx, win_y - dy))
+                .map_err(|e: tauri::Error| e.to_string())?;
+        }
+    }
+
+    // Set WebView2 background to fully transparent via COM API, AFTER the resize
+    // so the controller state is applied to the final window dimensions.
+    #[cfg(windows)]
+    apply_webview_transparency(&overlay).map_err(|e| e.to_string())?;
+
     overlay
         .set_ignore_cursor_events(true)
         .map_err(|e: tauri::Error| e.to_string())?;
@@ -159,6 +245,11 @@ pub fn set_overlay_interactive(app: AppHandle, interactive: bool) -> Result<(), 
         overlay
             .set_ignore_cursor_events(!interactive)
             .map_err(|e: tauri::Error| e.to_string())?;
+        // Toggling the layered-transparent flag on Windows can cause the WebView2
+        // surface to revert to an opaque default background — re-apply transparency
+        // to keep the overlay see-through during drawing.
+        #[cfg(windows)]
+        apply_webview_transparency(&overlay).map_err(|e: tauri::Error| e.to_string())?;
     }
     Ok(())
 }

--- a/src-tauri/src/commands/overlay.rs
+++ b/src-tauri/src/commands/overlay.rs
@@ -6,11 +6,12 @@ use tauri::{
 };
 
 #[cfg(windows)]
-use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
+use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
 #[cfg(windows)]
 use windows::Win32::UI::WindowsAndMessaging::{
-    CallNextHookEx, SetWindowsHookExW, UnhookWindowsHookEx, HHOOK, MSLLHOOKSTRUCT,
-    WH_MOUSE_LL, WM_LBUTTONDOWN, WM_MBUTTONDOWN, WM_RBUTTONDOWN,
+    CallNextHookEx, GetWindowLongPtrW, SetWindowLongPtrW, SetWindowsHookExW, UnhookWindowsHookEx,
+    GWL_EXSTYLE, HHOOK, MSLLHOOKSTRUCT, WH_MOUSE_LL, WM_LBUTTONDOWN, WM_MBUTTONDOWN,
+    WM_RBUTTONDOWN, WS_EX_LAYERED, WS_EX_TRANSPARENT,
 };
 
 static HOOK_ACTIVE: AtomicBool = AtomicBool::new(false);
@@ -239,17 +240,54 @@ pub async fn hide_overlay(app: AppHandle) -> Result<(), String> {
 
 // ─── Overlay interactivity ───
 
+/// Toggles click-through on the overlay at the Win32 ex-style level while
+/// preserving WS_EX_LAYERED. Tauri/wry's `set_ignore_cursor_events` removes
+/// both WS_EX_TRANSPARENT AND WS_EX_LAYERED when deactivating click-through,
+/// which destroys WebView2's per-pixel transparency. Manipulating only
+/// WS_EX_TRANSPARENT keeps the window in layered mode so transparency
+/// survives the toggle.
+#[cfg(windows)]
+fn set_click_through_preserving_layered(
+    overlay: &tauri::WebviewWindow,
+    click_through: bool,
+) -> Result<(), String> {
+    let hwnd_raw = overlay.hwnd().map_err(|e| e.to_string())?;
+    let hwnd = HWND(hwnd_raw.0 as *mut _);
+    let layered = WS_EX_LAYERED.0 as isize;
+    let transparent = WS_EX_TRANSPARENT.0 as isize;
+    unsafe {
+        let current = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+        // Always force WS_EX_LAYERED on; flip WS_EX_TRANSPARENT per request.
+        let new_style = if click_through {
+            (current | layered) | transparent
+        } else {
+            (current | layered) & !transparent
+        };
+        if new_style != current {
+            SetWindowLongPtrW(hwnd, GWL_EXSTYLE, new_style);
+        }
+    }
+    Ok(())
+}
+
+
 #[tauri::command]
 pub fn set_overlay_interactive(app: AppHandle, interactive: bool) -> Result<(), String> {
     if let Some(overlay) = app.get_webview_window("overlay") {
+        // On Windows, bypass Tauri's set_ignore_cursor_events and toggle
+        // WS_EX_TRANSPARENT directly so WS_EX_LAYERED is preserved — otherwise
+        // WebView2 loses per-pixel transparency when switching to interactive.
+        #[cfg(windows)]
+        {
+            set_click_through_preserving_layered(&overlay, !interactive)?;
+            // Re-apply WebView2 DefaultBackgroundColor defensively in case the
+            // composition state was touched.
+            apply_webview_transparency(&overlay).map_err(|e: tauri::Error| e.to_string())?;
+        }
+        #[cfg(not(windows))]
         overlay
             .set_ignore_cursor_events(!interactive)
             .map_err(|e: tauri::Error| e.to_string())?;
-        // Toggling the layered-transparent flag on Windows can cause the WebView2
-        // surface to revert to an opaque default background — re-apply transparency
-        // to keep the overlay see-through during drawing.
-        #[cfg(windows)]
-        apply_webview_transparency(&overlay).map_err(|e: tauri::Error| e.to_string())?;
     }
     Ok(())
 }

--- a/src/overlay/OverlayApp.tsx
+++ b/src/overlay/OverlayApp.tsx
@@ -16,16 +16,26 @@ type WebcamCorner = "br" | "bl" | "tl" | "tr";
 const WEBCAM_MARGIN = 25;
 const WEBCAM_SIZE = 150;
 
+/**
+ * Returns the webcam bubble position in window-local coordinates, sitting
+ * inside the recorded region (not in the outline pad area).
+ *
+ * The overlay window is slightly larger than the recording region (padded by
+ * `pad` pixels on each side where screen space allows) so the region outline
+ * border sits outside the capture. The webcam must stay inside the recorded
+ * region, so corners are offset inward by the pad amount.
+ */
 function cornerToPos(
   corner: WebcamCorner,
-  region: { x: number; y: number; width: number; height: number }
+  recorded: { width: number; height: number },
+  pad: { left: number; top: number; right: number; bottom: number }
 ) {
   const offset = WEBCAM_SIZE + WEBCAM_MARGIN;
   switch (corner) {
-    case "br": return { x: region.x + region.width - offset, y: region.y + region.height - offset };
-    case "bl": return { x: region.x + WEBCAM_MARGIN, y: region.y + region.height - offset };
-    case "tl": return { x: region.x + WEBCAM_MARGIN, y: region.y + WEBCAM_MARGIN };
-    case "tr": return { x: region.x + region.width - offset, y: region.y + WEBCAM_MARGIN };
+    case "br": return { x: pad.left + recorded.width - offset, y: pad.top + recorded.height - offset };
+    case "bl": return { x: pad.left + WEBCAM_MARGIN, y: pad.top + recorded.height - offset };
+    case "tl": return { x: pad.left + WEBCAM_MARGIN, y: pad.top + WEBCAM_MARGIN };
+    case "tr": return { x: pad.left + recorded.width - offset, y: pad.top + WEBCAM_MARGIN };
   }
 }
 
@@ -45,7 +55,12 @@ export default function OverlayApp() {
   const [drawing, setDrawing] = useState<Shape | null>(null);
   const [webcamVisible, setWebcamVisible] = useState(false);
 
-  // Read recording region from URL query params (set by show_overlay command)
+  // Read recording region + outline pad values from URL query params
+  // (set by show_overlay command). The overlay window is slightly larger than
+  // the recorded region (by pad pixels on each side, where screen space allows)
+  // so the outline border sits outside the captured area. Window-local origin
+  // (0,0) therefore corresponds to (region.x - padLeft, region.y - padTop) in
+  // screen coords.
   const params = new URLSearchParams(window.location.search);
   const region = {
     x: parseInt(params.get("x") || "0"),
@@ -53,9 +68,17 @@ export default function OverlayApp() {
     width: parseInt(params.get("w") || String(window.innerWidth)),
     height: parseInt(params.get("h") || String(window.innerHeight)),
   };
+  const pad = {
+    left: parseInt(params.get("pl") || "0"),
+    top: parseInt(params.get("pt") || "0"),
+    right: parseInt(params.get("pr") || "0"),
+    bottom: parseInt(params.get("pb") || "0"),
+  };
+  // Window origin in screen coords (for translating mouse-hook events)
+  const windowOrigin = { x: region.x - pad.left, y: region.y - pad.top };
 
   const [webcamCorner, setWebcamCorner] = useState<WebcamCorner | null>("br");
-  const [webcamPos, setWebcamPos] = useState(() => cornerToPos("br", region));
+  const [webcamPos, setWebcamPos] = useState(() => cornerToPos("br", region, pad));
   const [draggingWebcam, setDraggingWebcam] = useState(false);
   const dragOffset = useRef({ x: 0, y: 0 });
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -82,9 +105,9 @@ export default function OverlayApp() {
   // Sync webcamPos when corner is set via hotkey
   useEffect(() => {
     if (webcamCorner) {
-      setWebcamPos(cornerToPos(webcamCorner, region));
+      setWebcamPos(cornerToPos(webcamCorner, region, pad));
     }
-  }, [webcamCorner, region.x, region.y, region.width, region.height]);
+  }, [webcamCorner, region.x, region.y, region.width, region.height, pad.left, pad.top]);
 
   // Listen for cycle webcam position events (Ctrl+Shift+E)
   useEffect(() => {
@@ -137,22 +160,30 @@ export default function OverlayApp() {
     const unlisten = listen<{ x: number; y: number; button: string }>(
       "mouse-click",
       (event) => {
-        const { x, y, button } = event.payload;
+        const { x: screenX, y: screenY, button } = event.payload;
 
-        // Check if click is on the webcam bubble — if so, start drag
+        // Translate screen coords (from mouse hook) to window-local coords.
+        // The overlay window is positioned at windowOrigin (region minus pads),
+        // so window-local origin corresponds to the top-left of the window.
+        const localX = screenX - windowOrigin.x;
+        const localY = screenY - windowOrigin.y;
+
+        // Check if click is on the webcam bubble — if so, start drag.
+        // Both webcamPos and localX/Y are in window-local coords.
         if (webcamVisibleRef.current && button === "left") {
           const wp = webcamPosRef.current;
           const cx = wp.x + 75; // center of 150px bubble
           const cy = wp.y + 75;
-          const dist = Math.sqrt((x - cx) ** 2 + (y - cy) ** 2);
+          const dist = Math.sqrt((localX - cx) ** 2 + (localY - cy) ** 2);
           if (dist <= 75) {
             // Click is on webcam — make overlay interactive and start drag
-            dragOffset.current = { x: x - wp.x, y: y - wp.y };
+            dragOffset.current = { x: localX - wp.x, y: localY - wp.y };
             invoke("set_overlay_interactive", { interactive: true }).catch(console.error);
             setDraggingWebcam(true);
             setWebcamCorner(null); // freeform — next Ctrl+Shift+E resets to br
 
             const handleMove = (ev: MouseEvent) => {
+              // ev.clientX/Y are already window-local (browser events)
               setWebcamPos({
                 x: ev.clientX - dragOffset.current.x,
                 y: ev.clientY - dragOffset.current.y,
@@ -174,7 +205,7 @@ export default function OverlayApp() {
         }
 
         const id = Date.now() + Math.random();
-        setRipples((prev) => [...prev.slice(-9), { id, x, y, button }]);
+        setRipples((prev) => [...prev.slice(-9), { id, x: localX, y: localY, button }]);
         setTimeout(() => {
           setRipples((prev) => prev.filter((r) => r.id !== id));
         }, 600);
@@ -286,30 +317,28 @@ export default function OverlayApp() {
           </div>
         )}
 
-        {/* Recording region outline — sits just outside the region so the border
-            isn't captured by FFmpeg. Falls back to on-the-edge if the region
-            touches the screen boundary. */}
-        {(() => {
-          const canExpandLeft = region.x >= 2;
-          const canExpandTop = region.y >= 2;
-          const canExpandRight = region.x + region.width + 2 <= window.innerWidth;
-          const canExpandBottom = region.y + region.height + 2 <= window.innerHeight;
-          return (
-            <div
-              style={{
-                position: "absolute",
-                left: canExpandLeft ? region.x - 2 : region.x,
-                top: canExpandTop ? region.y - 2 : region.y,
-                width: region.width + (canExpandLeft ? 2 : 0) + (canExpandRight ? 2 : 0),
-                height: region.height + (canExpandTop ? 2 : 0) + (canExpandBottom ? 2 : 0),
-                border: "2px dashed #d1d5db",
-                boxSizing: "border-box",
-                pointerEvents: "none",
-                zIndex: 1,
-              }}
-            />
-          );
-        })()}
+        {/* Recording region outline — the overlay window is padded by `pad`
+            pixels on each side beyond the recording region (where screen space
+            permits). We explicitly size the outline to the INTENDED window size
+            (pad + recorded region + pad) rather than relying on window.innerWidth
+            because the OS may clip the window near screen edges. With border-box
+            + 2px border, the inner edge aligns with the recorded region boundary,
+            putting the border in the pad area outside the capture. When a pad
+            is 0 (no screen room), the border on that side falls back to being
+            inside the recording and will be visible in the final video. */}
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            top: 0,
+            width: pad.left + region.width + pad.right,
+            height: pad.top + region.height + pad.bottom,
+            border: "2px dashed #d1d5db",
+            boxSizing: "border-box",
+            pointerEvents: "none",
+            zIndex: 1,
+          }}
+        />
 
 
         {/* Click ripples */}
@@ -405,6 +434,10 @@ export default function OverlayApp() {
             top: webcamPos.y,
             width: 150,
             height: 150,
+            // border-box so the 3px border is drawn INSIDE the 150x150 bounds,
+            // keeping the bubble's visual size aligned with our corner math
+            // (which assumes a 150x150 total footprint).
+            boxSizing: "border-box",
             borderRadius: "50%",
             overflow: "hidden",
             border: "3px solid rgba(255,255,255,0.8)",


### PR DESCRIPTION
## Summary

Significant overlay + recording feature work beyond the v0.1.0 baseline. See [docs/plans/](docs/plans/) for the per-feature plan docs and their status markers.

### Shipped in this PR

- **Plan 01 — Webcam position cycling** — `Ctrl+Shift+E` cycles webcam through four corners of the region; manual drag resets to freeform.
- **Plan 02 — Recording region outline** — light-gray dashed border around the captured region so users know the capture bounds.
- **Plan 03 (partial) — Microphone audio + audio level indicator** — separate `MIC` / `SYS` toggles in the title bar; mic audio mixes with any system audio via FFmpeg `amix`; live 5-bar frequency visualizer appears while recording. `SYS` is intentionally disabled with a "coming in a future release" tooltip since `virtual-audio-capturer` isn't commonly installed (infrastructure is in place for re-enabling).
- **Plan 04 (core) — Region-sized overlay + transparency fixes**
  - Overlay window now sized and positioned to match the recording region (not fullscreen).
  - Outline sits in a 2px pad outside the captured area (not in the recording).
  - Windows frameless-window chrome compensation (~8px offset on L/R/B) so the inner area lands precisely.
  - Transparency-during-drawing fixed by directly toggling `WS_EX_TRANSPARENT` via Win32, preserving `WS_EX_LAYERED` that Tauri's own API was removing.
- **Plan 05 — Timeout investigation** — resolved as tooling-level (Claude Code's Monitor), no SnippingZo bug.
- **Plan 06 — Pill buttons blocked during drawing** — auto-resolved by Plan 04 since the overlay no longer covers the pill area.
- **Plan 07 — Context-aware `Ctrl+Shift+S`** — takes a screenshot when idle, stops the recording when active. Fixes a latent bug where the capture shortcut leaked into recording mode and gives users a keyboard escape.

### Deferred

- Plan 04 polish items: DPI scaling + `gdigrab` DPI fix + ripple cap + multi-monitor. Low priority at 100% DPI / single-monitor setups; captured for a future pass.

## Test plan

- [x] Start a region recording in the middle of the screen — overlay snaps to the region; outline visible on the overlay but NOT captured in the final mp4
- [x] Activate rectangle/arrow drawing — overlay stays transparent; shapes render inside the region; `Ctrl+Shift+Z` clears
- [x] `Ctrl+Shift+E` cycles webcam corners inside the recorded region
- [x] `Ctrl+Shift+S` stops an active recording; takes a screenshot when idle
- [x] `MIC` toggle enables microphone audio; audio indicator animates with voice; mp4 contains mic audio
- [x] Pill tool/stop buttons remain clickable while drawing tool active (region in middle of screen)
- [ ] Multi-monitor behavior — not tested (deferred)
- [ ] hi-DPI behavior — not tested (deferred; user on 100% DPI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)