### PR TITLE
fix(overlay): widen outline pad to 10px as WebView2 drift workaround

### DIFF
--- a/docs/plans/08-webview-content-drift-root-cause.md
+++ b/docs/plans/08-webview-content-drift-root-cause.md
@@ -1,0 +1,110 @@
+# Plan 08 — Root-Cause Fix: WebView2 Content Drift on First Interaction
+
+> **Status**: 🚧 Deferred for a future release. Current workaround: `OUTLINE_PAD = 10` in [overlay.rs](../../src-tauri/src/commands/overlay.rs) gives enough buffer for the drift to stay outside the captured region.
+
+## Context
+
+After Plan 04 shipped, testing revealed a subtle bug: **when a drawing tool is activated and the user clicks the overlay for the first time, the entire WebView2 content drifts ~8 pixels horizontally**. The window position at the OS level does NOT change (confirmed via `outer_position` / `inner_position` logs), so the drift is internal to WebView2's composition surface.
+
+Consequences:
+- The region outline, webcam bubble, and click ripples all shift as a group.
+- The outline's edge on one side ends up inside the captured region, so it gets baked into the final video.
+
+The workaround in the shipping build: expand the overlay window's outline pad from 2px to 10px on each side (where screen space permits). The outline now sits ~8px outside the recording by default, so even after the 8px drift it remains in the pad area and isn't captured. Visually, the outline frame sits slightly further from the region boundary than optimal.
+
+## Current Workaround (shipped)
+
+[src-tauri/src/commands/overlay.rs](../../src-tauri/src/commands/overlay.rs):
+```rust
+const OUTLINE_PAD: i32 = 10;
+```
+
+The frontend uses `pad.left + region.width + pad.right` to size the outline div, so the change is automatic end-to-end.
+
+## What We Tried That Didn't Work
+
+### 1. WS_THICKFRAME strip
+Removed `WS_THICKFRAME` from the window's base style via `SetWindowLongPtrW` + `SetWindowPos(SWP_FRAMECHANGED)`. Theory: frameless Tauri windows still have an 8px resize border inherited from the thick frame. Logs after strip:
+```
+before strip_thick_frame: outer=(130,130) inner=(138,130)
+after  strip_thick_frame: outer=(130,130) inner=(138,130)  ← unchanged
+```
+The offset persists — it comes from somewhere other than `WS_THICKFRAME`.
+
+### 2. WndProc subclass with WM_NCCALCSIZE interception
+Replaced the window's `WndProc` via `SetWindowLongPtrW(hwnd, GWLP_WNDPROC, ...)`, returning `0` for `WM_NCCALCSIZE` so the client area equals the window area (no chrome).
+
+**Caused the app to hang** because the implementation used `Mutex<Option<isize>>` for the original WndProc pointer, and the hot-path message handler locked that mutex on every single Windows message — thousands per second. Stashed as `stash@{0}` on this investigation branch.
+
+### 3. Re-apply transparency on interactive toggle
+Added `apply_webview_transparency()` call after `set_click_through_preserving_layered` to force WebView2 back to transparent. No effect on the drift (drift happens on click, not on tool activation, so re-applying during activation doesn't prevent it).
+
+## Root-Cause Hypotheses (to investigate later)
+
+1. **WebView2 composition surface remapping**: On first mouse interaction, WebView2 may switch its composition surface between window-outer and window-inner coordinate frames, triggering the 8px shift.
+
+2. **DWM frame margin**: Modern Windows always reserves invisible DWM margins around frameless windows for composition. These margins exist regardless of `WS_THICKFRAME`. Only subclassing `WM_NCCALCSIZE` eliminates them.
+
+3. **Focus activation redraw**: When the overlay receives its first mouse event that isn't click-through, Windows promotes it to active status, which may trigger a full frame recomposition with different pixel alignment.
+
+## Proposed Fix Approaches
+
+### Option A: Safer WndProc subclass (high confidence)
+Same concept as attempt #2, but use `AtomicIsize` / `AtomicPtr` instead of a Mutex so the hot-path handler is lock-free.
+
+```rust
+static ORIGINAL_WNDPROC: AtomicIsize = AtomicIsize::new(0);
+
+unsafe extern "system" fn overlay_wnd_proc(
+    hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM
+) -> LRESULT {
+    if msg == WM_NCCALCSIZE && wparam.0 != 0 {
+        return LRESULT(0);
+    }
+    let orig = ORIGINAL_WNDPROC.load(Ordering::Acquire);
+    if orig == 0 { return LRESULT(0); }
+    let proc: WNDPROC = std::mem::transmute(orig);
+    CallWindowProcW(proc, hwnd, msg, wparam, lparam)
+}
+```
+
+**Risks**:
+- `WM_NCCALCSIZE` returning 0 may break WebView2's internal rendering assumptions (it expects some margin).
+- Other messages forwarded through `CallWindowProcW` might have side effects if wry internally subclasses too (chain-of-subclass conflict).
+
+**Validation plan**:
+- Before enabling the subclass, capture a baseline of what messages the current window handles.
+- After enabling, check that all normal interactions (keyboard, focus, drag, resize) still work.
+
+### Option B: DWM frame extension
+Use `DwmExtendFrameIntoClientArea(hwnd, &MARGINS { -1, -1, -1, -1 })` to push the DWM frame margin into the client area, effectively making chrome 0.
+
+Less invasive than subclassing but may still leave some subtle offset depending on Windows version.
+
+### Option C: Eliminate the overlay's reliance on consistent layout
+Instead of depending on overlay window position being pixel-perfect, **render the region outline as a separate tiny Win32 layered window** (per edge, or as a single frame window around the region). Native Win32 windows don't have WebView2's composition quirks.
+
+More code but architecturally cleaner and eliminates the class of bugs entirely.
+
+### Option D: Accept the drift, compensate in React
+On the frontend, capture the webview origin at mount and again on first mousedown via a native hook. If it changed, apply a compensating CSS `transform: translate(...)` to counter the drift. Keeps the overlay always visible but relies on a potentially fragile measurement.
+
+## Recommended Path
+
+**Option A** first (safer WndProc subclass). If it causes rendering or event-handling regressions, fall back to **Option B** (DWM extend-into-client). **Option C** only if both A and B fail.
+
+Before shipping any of these, the verification from [04-phase-6-region-sizing-and-dpi.md](./04-phase-6-region-sizing-and-dpi.md) should also be re-checked:
+- Transparency stays during drawing tool activation
+- Outline no longer captured in recording (even at the edge case where the region touches the screen boundary)
+- No hang on window creation or on first user interaction
+
+## Files to Modify (when fix is picked up)
+
+- [src-tauri/src/commands/overlay.rs](../../src-tauri/src/commands/overlay.rs) — add WndProc subclass or DWM extension logic; revert `OUTLINE_PAD = 10` back to `2` once drift is eliminated.
+
+## Success Criteria
+
+- `inner_position` equals `outer_position` (no chrome) at `show_overlay done` log point.
+- Clicking on the overlay with a drawing tool active produces no visual shift of the outline, webcam, or ripples.
+- Recording after activating a drawing tool does NOT contain the outline in the output video.
+- App remains responsive and interactive through all recording scenarios.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -25,6 +25,9 @@ Sequenced plan documents for remaining overlay work. Each plan is self-contained
 7. [07 — Context-Aware `Ctrl+Shift+S` (Screenshot / Stop Recording)](./07-stop-recording-hotkey.md) ✅
    Reuses the existing capture shortcut as a state-dependent toggle: takes a screenshot when idle, stops the recording when one is active. Provides keyboard escape for the Plan 06 blocking bug.
 
+8. [08 — Root-Cause Fix: WebView2 Content Drift on First Interaction](./08-webview-content-drift-root-cause.md) 🚧
+   Root-cause fix for the ~8px WebView2 content drift that caused the region outline to be captured on one side. Current release ships a workaround (larger outline pad); proper fix via WndProc subclass or DWM frame extension deferred to a future release.
+
 ## Dependencies
 
 ```

--- a/src-tauri/src/commands/overlay.rs
+++ b/src-tauri/src/commands/overlay.rs
@@ -107,7 +107,11 @@ pub async fn show_overlay(
     // so the region-outline border sits outside the capture. If the region
     // touches the monitor edge on any side, pad on that side is 0 and the
     // outline on that side falls back to being inside the recording.
-    const OUTLINE_PAD: i32 = 2;
+    //
+    // The pad is intentionally larger than strictly needed for a 2px border so
+    // that WebView2 content-shift on first interaction (~8px horizontally on
+    // this platform) doesn't push the outline into the captured region.
+    const OUTLINE_PAD: i32 = 10;
     let region_x = x.unwrap_or(0);
     let region_y = y.unwrap_or(0);
     let region_w = width.unwrap_or(1920).max(1);


### PR DESCRIPTION
## Summary

After PR #2 shipped, testing revealed that when a drawing tool (rectangle/arrow) is activated and the user makes their first click, the WebView2 rendered content shifts ~8px horizontally. The OS window stays put — everything inside the webview (outline, webcam, click ripples) moves as a group. Consequence: one edge of the region outline lands inside the captured region and is baked into the final video.

This PR ships a **pragmatic workaround** and documents a root-cause fix for a future release.

## Workaround (in this PR)

- [src-tauri/src/commands/overlay.rs](src-tauri/src/commands/overlay.rs): `OUTLINE_PAD` raised from `2` → `10`.
- The overlay window now expands 10px beyond the recording region on each side (where screen space permits), and the 2px dashed outline sits in that pad area. Even after the ~8px drift, the border stays outside the captured region.
- Visible trade-off on screen: the dashed frame appears ~8px further from the region edge than before. The recording itself is clean.

## Root-cause fix (deferred)

[docs/plans/08-webview-content-drift-root-cause.md](docs/plans/08-webview-content-drift-root-cause.md) documents:
- What we tried that didn't work (WS_THICKFRAME strip; WndProc subclass with a Mutex that hung the app due to hot-path lock contention).
- Three candidate approaches for a proper fix (safer lock-free WndProc subclass, DWM frame extension, native Win32 outline window).
- Success criteria for the fix and the files it will touch.

## Test plan

- [x] Record a region in the middle of the screen, activate rectangle tool, draw, stop — no outline visible in the recording.
- [x] Transparency still holds during drawing (unchanged from PR #2).
- [x] Webcam, ripples, and annotations still render in the correct positions.
- [ ] Record with region near the screen edge — on edges where pad = 0 the outline still falls back to being inside the recording (documented limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)