### PR TITLE
ui: rename Rectangle→Selection, disable Window mode, add Plan 09

### DIFF
--- a/docs/plans/09-window-capture-mode.md
+++ b/docs/plans/09-window-capture-mode.md
@@ -1,0 +1,112 @@
+# Plan 09 — Window Capture Mode
+
+> **Status**: 🚧 Future release. The UI currently exposes a "Window" option in the capture-mode dropdown but clicking it does nothing useful.
+
+## Context
+
+The title bar's capture-mode dropdown shows three options: **Rectangle**, **Fullscreen**, **Window**. The type definition in [src/types/capture.ts](../../src/types/capture.ts) declares a fourth mode, `"freeform"`, that isn't exposed in the UI.
+
+Of the three visible options:
+- **Rectangle** ✅ — user drags a selection rectangle, app captures that area.
+- **Fullscreen** ✅ — captures the entire screen immediately.
+- **Window** ❌ — **non-functional**. Selecting it shows the capture overlay but the mouse handlers early-return in [CaptureOverlay.tsx:123](../../src/components/capture/CaptureOverlay.tsx#L123) (`if (mode !== "rectangular") return;`). The user has no way to complete the capture except to press Escape.
+
+This plan describes what "Window mode" should do and how to implement it.
+
+## Intended Behavior
+
+Mimics the Windows Snipping Tool's "Window Snip":
+
+1. User opens capture mode with **Window** selected.
+2. The capture overlay shows a screenshot of the desktop (as it does for Rectangle mode).
+3. As the user moves the mouse, the top-level window **under the cursor** is highlighted with a colored outline.
+4. On click, the app captures the rectangular bounds of that window and exits capture mode.
+5. Pressing Escape cancels without capturing.
+
+Good to have (could be added later):
+- Filter to only highlight windows on the current monitor.
+- Exclude SnippingZo's own capture overlay from the window list (it's fullscreen and would always be "the window under cursor").
+- Visual feedback for child vs top-level windows (usually we only want top-level).
+
+## Current State
+
+### Frontend: [src/components/capture/CaptureOverlay.tsx](../../src/components/capture/CaptureOverlay.tsx)
+- Shows the overlay for rectangular and window modes (line 86).
+- Mouse handlers early-return for non-rectangular modes (line 123).
+- No highlight overlay, no click-to-capture for window mode.
+
+### Backend: [src-tauri/src/commands/capture.rs](../../src-tauri/src/commands/capture.rs)
+- Has commands for `capture_fullscreen`, `capture_fullscreen_fast`, `capture_region`, `crop_image`.
+- No command for enumerating windows or capturing by window handle.
+
+### Types: [src/types/capture.ts](../../src/types/capture.ts)
+```ts
+export type CaptureMode = "rectangular" | "freeform" | "window" | "fullscreen";
+```
+`"freeform"` is declared but not used anywhere in the UI or capture flow. It can be ignored or removed in this plan (see "Out of Scope").
+
+## Implementation Steps
+
+### 1. New Rust command: `list_top_level_windows`
+
+Returns a list of visible, top-level windows with their bounds and titles.
+
+```rust
+#[tauri::command]
+pub fn list_top_level_windows() -> Result<Vec<WindowInfo>, String> {
+    // Use Win32 EnumWindows with a callback that:
+    //   - checks IsWindowVisible(hwnd)
+    //   - skips windows without a title or with WS_EX_TOOLWINDOW
+    //   - excludes our own overlay window by HWND comparison
+    //   - gets bounds via DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS)
+    //     (preferred over GetWindowRect, which includes shadow)
+    // Returns Vec<WindowInfo { hwnd: i64, title: String, x, y, w, h }>
+}
+```
+
+Exclude the SnippingZo overlay: store its HWND in a `Mutex<Option<isize>>` when `show_overlay` runs (or look up by window label via Tauri's `get_webview_window("overlay").hwnd()`).
+
+### 2. New Rust command: `capture_window_bounds`
+
+Takes bounds from the frontend (after the user clicked a window) and captures that region. Could be a thin wrapper over the existing `capture_region` with the window's bounds.
+
+### 3. Frontend: window overlay behavior
+
+In [CaptureOverlay.tsx](../../src/components/capture/CaptureOverlay.tsx):
+- When `mode === "window"`, on mount call `invoke("list_top_level_windows")` to get the list.
+- On `onMouseMove`, find which window's bounds contain the cursor (`e.clientX, e.clientY`).
+  - Prefer the window with the smallest area containing the point (accounts for z-order only approximately; the list is already in top-to-bottom z-order from `EnumWindows`, so the first match is on top).
+- Render a highlight div (semi-transparent colored fill + solid border) at the found window's bounds.
+- On click, call `capture_region` with those bounds and finish capture.
+
+### 4. UI visual polish
+
+Highlight style suggestions:
+- `background: "rgba(59, 130, 246, 0.2)"` (tailwind blue-500 at 20%)
+- `border: "2px solid #3b82f6"` (blue-500)
+- Show the window title near the cursor as a small tooltip.
+
+## Verification
+
+- [ ] Open capture in Window mode → overlay appears with screenshot.
+- [ ] Move cursor over different windows → highlight follows, outlines visible window bounds.
+- [ ] Click a window → capture that window's bounds, not including the shadow.
+- [ ] Click on empty desktop → no highlight, no capture (or capture the desktop as fallback — decide during implementation).
+- [ ] SnippingZo's own main window doesn't appear as a target while in capture mode.
+- [ ] Multi-monitor: highlighting works for windows on secondary monitors too.
+
+## Out of Scope
+
+- **Freeform mode**: the `"freeform"` type variant is currently dead code. It could be implemented separately (drag path to select) or deleted. Not addressed by this plan.
+- **Per-element snip**: e.g. capturing a single toolbar or button inside a window. Out of scope; window-level is enough.
+
+## Files to Modify (when implemented)
+
+- [src-tauri/src/commands/capture.rs](../../src-tauri/src/commands/capture.rs) — new commands for enumeration + capture.
+- [src-tauri/src/lib.rs](../../src-tauri/src/lib.rs) — register commands.
+- [src/components/capture/CaptureOverlay.tsx](../../src/components/capture/CaptureOverlay.tsx) — window-mode handlers + highlight UI.
+- [src/types/capture.ts](../../src/types/capture.ts) — add `WindowInfo` interface; consider removing or implementing `"freeform"`.
+
+## Dependencies
+
+None. Can be picked up after the drift root-cause fix (Plan 08) or independently.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -28,6 +28,9 @@ Sequenced plan documents for remaining overlay work. Each plan is self-contained
 8. [08 — Root-Cause Fix: WebView2 Content Drift on First Interaction](./08-webview-content-drift-root-cause.md) 🚧
    Root-cause fix for the ~8px WebView2 content drift that caused the region outline to be captured on one side. Current release ships a workaround (larger outline pad); proper fix via WndProc subclass or DWM frame extension deferred to a future release.
 
+9. [09 — Window Capture Mode](./09-window-capture-mode.md) 🚧
+   The capture-mode dropdown has a "Window" option that currently does nothing. Plan covers enumerating top-level windows, highlighting the one under cursor, and click-to-capture its bounds.
+
 ## Dependencies
 
 ```

--- a/src/components/layout/TitleBar.tsx
+++ b/src/components/layout/TitleBar.tsx
@@ -17,10 +17,23 @@ import { AudioLevelIndicator } from "../recording/AudioLevelIndicator";
 import { APP_NAME } from "../../lib/constants";
 import type { CaptureMode, DelayOption } from "../../types/capture";
 
-const CAPTURE_MODES: { mode: CaptureMode; label: string; icon: React.ReactNode }[] = [
-  { mode: "rectangular", label: "Rectangle", icon: <Square size={14} /> },
+const CAPTURE_MODES: {
+  mode: CaptureMode;
+  label: string;
+  icon: React.ReactNode;
+  disabled?: boolean;
+  disabledReason?: string;
+}[] = [
+  { mode: "rectangular", label: "Selection", icon: <Square size={14} /> },
   { mode: "fullscreen", label: "Fullscreen", icon: <Maximize size={14} /> },
-  { mode: "window", label: "Window", icon: <Square size={14} /> },
+  {
+    mode: "window",
+    label: "Window",
+    icon: <Square size={14} />,
+    disabled: true,
+    disabledReason:
+      "Window capture — coming in a future release.",
+  },
 ];
 
 const DELAY_OPTIONS: { value: DelayOption; label: string }[] = [
@@ -149,7 +162,9 @@ export function TitleBar() {
           {CAPTURE_MODES.map((m) => (
             <button
               key={m.mode}
-              onClick={() => setMode(m.mode)}
+              onClick={() => !m.disabled && setMode(m.mode)}
+              disabled={m.disabled}
+              title={m.disabled ? m.disabledReason : undefined}
               style={{
                 display: "flex",
                 alignItems: "center",
@@ -158,11 +173,19 @@ export function TitleBar() {
                 padding: "6px 8px",
                 borderRadius: 4,
                 border: "none",
-                cursor: "pointer",
-                backgroundColor: mode === m.mode ? "var(--accent-color)" : "transparent",
-                color: mode === m.mode ? "#fff" : "var(--text-primary)",
+                cursor: m.disabled ? "not-allowed" : "pointer",
+                backgroundColor:
+                  mode === m.mode && !m.disabled
+                    ? "var(--accent-color)"
+                    : "transparent",
+                color: m.disabled
+                  ? "var(--text-tertiary, #999)"
+                  : mode === m.mode
+                  ? "#fff"
+                  : "var(--text-primary)",
                 fontSize: 12,
                 textAlign: "left",
+                opacity: m.disabled ? 0.55 : 1,
               }}
             >
               {m.icon}


### PR DESCRIPTION
## Summary

Polish pass on the capture-mode dropdown in the title bar.

### Changes

- **Rectangle → Selection**: the label \"Rectangle\" ambiguously suggested capturing a rectangular *window*. \"Selection\" more accurately describes the drag-to-select behavior.
- **Disable Window mode**: the option was previously clickable but non-functional — it showed the capture overlay but the mouse handlers early-returned for non-rectangular modes, trapping the user with only Escape to exit. The button is now dimmed and disabled with a tooltip:
  > Window capture — coming in a future release.
- **Plan 09 doc**: [docs/plans/09-window-capture-mode.md](docs/plans/09-window-capture-mode.md) describes the intended behavior (Win32 EnumWindows + WindowFromPoint + click-to-capture), the backend commands needed, and the frontend highlight UI, so the feature can be picked up cleanly later.

## Test plan

- [x] Open capture-mode dropdown — **Selection** appears instead of Rectangle
- [x] Selection mode still works (drag to capture)
- [x] Window option is greyed out; hovering shows the \"coming in a future release\" tooltip; clicking does nothing
- [x] Fullscreen mode unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)