### PR TITLE
rename: SnippingZo → Klipp across the codebase

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,7 +37,7 @@ body:
   - type: input
     id: version
     attributes:
-      label: SnippingZo Version
+      label: Klipp Version
       placeholder: "0.1.0"
     validations:
       required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to SnippingZo
+# Contributing to Klipp
 
 Thank you for your interest in contributing! This guide will help you get started.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SnippingZo
+# Klipp
 
 An open-source screenshot and screen recording tool with powerful annotation support. Built as an alternative to Microsoft Snipping Tool — with features it's missing.
 
@@ -54,8 +54,8 @@ An open-source screenshot and screen recording tool with powerful annotation sup
 ### Setup
 
 ```bash
-git clone https://github.com/FuselabsAI/SnippingZo.git
-cd SnippingZo
+git clone https://github.com/alemhar/klipp.git
+cd klipp
 npm install --legacy-peer-deps
 npm run tauri dev
 ```
@@ -70,7 +70,7 @@ Installers are generated in `src-tauri/target/release/bundle/`.
 
 ## Third-Party Dependencies
 
-**FFmpeg** — Screen recording uses [FFmpeg](https://ffmpeg.org/), a free and open-source multimedia framework licensed under LGPL/GPL. FFmpeg is **not bundled** with SnippingZo — it is downloaded automatically (~30MB) on first use of the screen recording feature. FFmpeg is stored in the app's local data directory and is only used for video encoding. You can also install FFmpeg manually via `winget install Gyan.FFmpeg`. Screenshot capture and all annotation features work without FFmpeg.
+**FFmpeg** — Screen recording uses [FFmpeg](https://ffmpeg.org/), a free and open-source multimedia framework licensed under LGPL/GPL. FFmpeg is **not bundled** with Klipp — it is downloaded automatically (~30MB) on first use of the screen recording feature. FFmpeg is stored in the app's local data directory and is only used for video encoding. You can also install FFmpeg manually via `winget install Gyan.FFmpeg`. Screenshot capture and all annotation features work without FFmpeg.
 
 ## Contributing
 

--- a/docs/plans/05-timeout-investigation.md
+++ b/docs/plans/05-timeout-investigation.md
@@ -5,10 +5,10 @@
 ## Findings (2026-04-17)
 
 ### What was reported
-User repeatedly saw "Monitor timed out — re-arm if needed." messages during Plan 01–04 development and assumed they were from the SnippingZo app itself.
+User repeatedly saw "Monitor timed out — re-arm if needed." messages during Plan 01–04 development and assumed they were from the Klipp app itself.
 
 ### Root cause
-The message comes from **Claude Code's `Monitor` tool** that the assistant uses to watch long-running background processes (like `npm run tauri dev`). It's an internal Claude Code tooling message surfaced in chat, not output from SnippingZo's Rust/React code.
+The message comes from **Claude Code's `Monitor` tool** that the assistant uses to watch long-running background processes (like `npm run tauri dev`). It's an internal Claude Code tooling message surfaced in chat, not output from Klipp's Rust/React code.
 
 **Distinguishing features**:
 - Format: `Monitor timed out — re-arm if needed.`
@@ -19,7 +19,7 @@ The message comes from **Claude Code's `Monitor` tool** that the assistant uses 
 **App-side**: there is currently **no reproducible app-level timeout**. None of the suspects below (`mpsc::channel` recv in `show_overlay`, WebView2 init stall, mouse-hook thread pump, Vite HMR) have surfaced a real failure during Plan 01, 02, or Plan 03 Step A testing.
 
 ### Verdict
-No code change needed in SnippingZo. The documented suspects remain valid design concerns — any of them could cause a real timeout if conditions change — but they are not observed today.
+No code change needed in Klipp. The documented suspects remain valid design concerns — any of them could cause a real timeout if conditions change — but they are not observed today.
 
 ### When to reopen
 Revisit this plan if the user sees timeouts:

--- a/docs/plans/09-window-capture-mode.md
+++ b/docs/plans/09-window-capture-mode.md
@@ -25,7 +25,7 @@ Mimics the Windows Snipping Tool's "Window Snip":
 
 Good to have (could be added later):
 - Filter to only highlight windows on the current monitor.
-- Exclude SnippingZo's own capture overlay from the window list (it's fullscreen and would always be "the window under cursor").
+- Exclude Klipp's own capture overlay from the window list (it's fullscreen and would always be "the window under cursor").
 - Visual feedback for child vs top-level windows (usually we only want top-level).
 
 ## Current State
@@ -64,7 +64,7 @@ pub fn list_top_level_windows() -> Result<Vec<WindowInfo>, String> {
 }
 ```
 
-Exclude the SnippingZo overlay: store its HWND in a `Mutex<Option<isize>>` when `show_overlay` runs (or look up by window label via Tauri's `get_webview_window("overlay").hwnd()`).
+Exclude the Klipp overlay: store its HWND in a `Mutex<Option<isize>>` when `show_overlay` runs (or look up by window label via Tauri's `get_webview_window("overlay").hwnd()`).
 
 ### 2. New Rust command: `capture_window_bounds`
 
@@ -92,7 +92,7 @@ Highlight style suggestions:
 - [ ] Move cursor over different windows → highlight follows, outlines visible window bounds.
 - [ ] Click a window → capture that window's bounds, not including the shadow.
 - [ ] Click on empty desktop → no highlight, no capture (or capture the desktop as fallback — decide during implementation).
-- [ ] SnippingZo's own main window doesn't appear as a target while in capture mode.
+- [ ] Klipp's own main window doesn't appear as a target while in capture mode.
 - [ ] Multi-monitor: highlighting works for windows on secondary monitors too.
 
 ## Out of Scope

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -17,7 +17,7 @@ Sequenced plan documents for remaining overlay work. Each plan is self-contained
    Region-sized overlay + outline + transparency-during-drawing shipped. DPI scaling, gdigrab DPI fix, ripple cap, and multi-monitor testing still pending (low priority at 100% DPI single-monitor).
 
 5. [05 — Timeout Investigation](./05-timeout-investigation.md) ✅ (no app bug)
-   Research task. Root cause was Claude Code's Monitor tool, not the SnippingZo app. No code change required.
+   Research task. Root cause was Claude Code's Monitor tool, not the Klipp app. No code change required.
 
 6. [06 — Fix: Pill Buttons Blocked by Active Overlay Tool](./06-pill-buttons-blocked-by-overlay.md) ✅ (resolved by Plan 04)
    Auto-fixed — region-sized overlay no longer covers the recording pill area for typical recordings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "snippingzo",
+  "name": "klipp",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "snippingzo",
+      "name": "klipp",
       "version": "0.1.0",
       "dependencies": {
         "@emoji-mart/data": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "snippingzo",
+  "name": "klipp",
   "private": true,
   "version": "0.1.0",
   "description": "An open-source screenshot and screen recording tool with annotation support",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "snippingzo"
+name = "klipp"
 version = "0.1.0"
 description = "An open-source screenshot and screen recording tool with annotation support"
 authors = ["FuselabsAI"]
 edition = "2021"
 
 [lib]
-name = "snippingzo_lib"
+name = "klipp_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -30,7 +30,7 @@
         { "path": "$DOWNLOAD/**" },
         { "path": "$PICTURE/**" },
         { "path": "$DESKTOP/**" },
-        { "path": "$HOME/SnippingZo/**" }
+        { "path": "$HOME/Klipp/**" }
       ]
     },
     "shell:allow-open",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    snippingzo_lib::run()
+    klipp_lib::run()
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -11,7 +11,7 @@ pub fn create_tray(app: &App) -> Result<(), Box<dyn std::error::Error>> {
     let separator = tauri::menu::PredefinedMenuItem::separator(app)?;
     let settings = MenuItem::with_id(app, "settings", "Settings", true, None::<&str>)?;
     let separator2 = tauri::menu::PredefinedMenuItem::separator(app)?;
-    let quit = MenuItem::with_id(app, "quit", "Quit SnippingZo", true, Some("Ctrl+Q"))?;
+    let quit = MenuItem::with_id(app, "quit", "Quit Klipp", true, Some("Ctrl+Q"))?;
 
     let menu = Menu::with_items(
         app,
@@ -28,7 +28,7 @@ pub fn create_tray(app: &App) -> Result<(), Box<dyn std::error::Error>> {
     TrayIconBuilder::new()
         .icon(app.default_window_icon().unwrap().clone())
         .menu(&menu)
-        .tooltip("SnippingZo")
+        .tooltip("Klipp")
         .on_menu_event(|app, event| match event.id.as_ref() {
             "new_snip" => {
                 let _ = app.emit("start-capture", "rectangular");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "SnippingZo",
+  "productName": "Klipp",
   "version": "0.1.0",
-  "identifier": "com.fuselabs.snippingzo",
+  "identifier": "com.fuselabs.klipp",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "SnippingZo",
+        "title": "Klipp",
         "width": 800,
         "height": 600
       }

--- a/src/components/layout/TitleBar.tsx
+++ b/src/components/layout/TitleBar.tsx
@@ -350,7 +350,7 @@ export function TitleBar() {
             if (!hasFfmpeg) {
               const shouldDownload = confirm(
                 "Screen recording requires FFmpeg (a free, open-source video encoder).\n\n" +
-                "SnippingZo will download it automatically (one-time only).\n" +
+                "Klipp will download it automatically (one-time only).\n" +
                 "This may take a minute depending on your internet speed.\n\n" +
                 "Click OK to download now."
               );

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const APP_NAME = "SnippingZo";
+export const APP_NAME = "Klipp";
 
 export const DEFAULT_PEN_COLOR = "#FF0000";
 export const DEFAULT_PEN_WIDTH = 3;


### PR DESCRIPTION
## Summary

Renames the app from **SnippingZo** to **Klipp** everywhere in the codebase. \"SnippingZo\" was uncomfortably close to Microsoft's Snipping Tool name and invited brand/trademark confusion. \"Klipp\" is short, brandable, and preserves the snip/clip intent.

## Scope

**15 files changed.** Verified with \`cargo check\` — the crate now builds as \`klipp\`.

### User-facing text
- \`README.md\`, \`CONTRIBUTING.md\`, \`bug_report.yml\`
- \`tauri.conf.json\` (\`productName\` + window \`title\`)
- \`src-tauri/src/tray.rs\` (\"Quit Klipp\" menu + tooltip)
- \`src/lib/constants.ts\` (\`APP_NAME\`)
- \`src/components/layout/TitleBar.tsx\` (FFmpeg download prompt)
- 3 plan docs with incidental mentions

### Package identifiers
- \`package.json\` + \`package-lock.json\` (\`name\`)
- \`src-tauri/Cargo.toml\` (package name + lib name → \`klipp_lib\`)
- \`src-tauri/src/main.rs\` (\`klipp_lib::run()\`)
- \`src-tauri/tauri.conf.json\` identifier → \`com.fuselabs.klipp\`

### Data directory path
- \`src-tauri/capabilities/default.json\`: \`\$HOME/SnippingZo/**\` → \`\$HOME/Klipp/**\`. No release has shipped, so no user-data migration is needed.

### Repo URL
- README clone URL updated to \`github.com/alemhar/klipp\` (repo already renamed by owner).

## What's NOT changed
- The local filesystem path of the project folder (still \`d:\FuselabsAI\Projects\SnippingZo\\` on the owner's machine) — preserved per owner preference.
- Rust crate authors (\"FuselabsAI\") — separate from app naming.

## Test plan

- [x] \`cargo check\` succeeds; lib compiles as \`klipp\`.
- [ ] \`npm install\` regenerates \`package-lock.json\` cleanly (already updated by hand).
- [ ] Full \`tauri dev\` launch shows \"Klipp\" in window title, tray tooltip, and Quit menu.
- [ ] Install artifact bundle name reflects \`klipp\` (from \`tauri build\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)