### PR TITLE
fix: resolve TypeScript errors blocking the production build

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import { useGlobalShortcut } from "./hooks/useGlobalShortcut";
 
 function App() {
   const { isCaptureMode, setIsCaptureMode, showSettings, activeTool } = useUIStore();
-  const { setCapturedImage, delay } = useCaptureStore();
+  const { delay } = useCaptureStore();
   const { undo, redo, addObject } = useCanvasStore();
   const [isDelaying, setIsDelaying] = useState(false);
   const { isRecording, isSelectingRegion } = useRecordingStore();

--- a/src/components/canvas/AnnotationCanvas.tsx
+++ b/src/components/canvas/AnnotationCanvas.tsx
@@ -16,7 +16,6 @@ import { useUIStore } from "../../stores/uiStore";
 import { TextNode } from "./TextNode";
 import { ImageOverlayNode } from "./ImageOverlayNode";
 import type {
-  CanvasObject,
   DrawingObject,
   ShapeObject,
   TextObject,

--- a/src/components/recording/RecordingControls.tsx
+++ b/src/components/recording/RecordingControls.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useCallback } from "react";
 import { Square, RectangleHorizontal, MoveUpRight, Trash2, Camera } from "lucide-react";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { getCurrentWindow, LogicalPosition, LogicalSize } from "@tauri-apps/api/window";
 import { emit } from "@tauri-apps/api/event";
 import { useRecordingStore } from "../../stores/recordingStore";
 import { useGlobalShortcut } from "../../hooks/useGlobalShortcut";
@@ -24,12 +24,10 @@ export function RecordingControls() {
     const setup = async () => {
       const mainWindow = getCurrentWindow();
       await mainWindow.setAlwaysOnTop(true);
-      await mainWindow.setSize({ type: "Logical", width: 400, height: 50 });
-      await mainWindow.setPosition({
-        type: "Logical",
-        x: Math.round(screen.width / 2 - 200),
-        y: 10,
-      });
+      await mainWindow.setSize(new LogicalSize(400, 50));
+      await mainWindow.setPosition(
+        new LogicalPosition(Math.round(screen.width / 2 - 200), 10)
+      );
       await mainWindow.setFocus();
     };
 

--- a/src/stores/canvasStore.ts
+++ b/src/stores/canvasStore.ts
@@ -39,8 +39,11 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
     set({
       past: [...past, objects],
       future: [],
+      // Spreading a Partial<CanvasObject> into a discriminated-union member
+      // widens the TS type; the cast preserves the runtime invariant that
+      // callers don't change an object's `type` via updateObject.
       objects: objects.map((o) =>
-        o.id === id ? { ...o, ...changes } : o
+        o.id === id ? ({ ...o, ...changes } as CanvasObject) : o
       ),
     });
   },

--- a/src/stores/recordingStore.ts
+++ b/src/stores/recordingStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { getCurrentWindow, LogicalPosition, LogicalSize } from "@tauri-apps/api/window";
 
 interface RecordingConfig {
   x: number;
@@ -149,8 +149,8 @@ export const useRecordingStore = create<RecordingState>((set, get) => ({
       const mainWindow = getCurrentWindow();
       await mainWindow.setAlwaysOnTop(false);
       if (saved) {
-        await mainWindow.setSize({ type: "Logical", width: saved.width, height: saved.height });
-        await mainWindow.setPosition({ type: "Logical", x: saved.x, y: saved.y });
+        await mainWindow.setSize(new LogicalSize(saved.width, saved.height));
+        await mainWindow.setPosition(new LogicalPosition(saved.x, saved.y));
       }
 
       set({ isRecording: false, config: null, savedWindowState: null });


### PR DESCRIPTION
## Summary

\`npm run tauri build\` runs \`tsc && vite build\` in \`beforeBuildCommand\`, which surfaced several pre-existing TypeScript errors that dev mode (no \`tsc\`) had been silently ignoring. Production builds couldn't complete until these were fixed.

All changes are lint-level — functionally identical to the dev-mode behavior, just makes the compiler happy.

## Fixes

- **\`src/App.tsx\`** — removed unused \`setCapturedImage\` destructure.
- **\`src/components/canvas/AnnotationCanvas.tsx\`** — removed unused \`CanvasObject\` type import.
- **\`src/components/recording/RecordingControls.tsx\`** + **\`src/stores/recordingStore.ts\`** — Tauri v2's \`LogicalSize\` / \`LogicalPosition\` are classes, not object literals. Switched from \`{ type: \"Logical\", width, height }\` → \`new LogicalSize(width, height)\` (same for Position).
- **\`src/stores/canvasStore.ts\`** — \`updateObject\` spreads \`Partial<CanvasObject>\` into a discriminated-union member. TypeScript widens the result because \`type\` could theoretically change. Added a single-line cast back to \`CanvasObject\` with a comment noting the invariant.

## Verification

- [x] \`npx tsc --noEmit\` passes cleanly.
- [x] \`npm run tauri build\` now proceeds past the frontend phase into Rust compilation.
- [ ] Once the release build completes end-to-end, verify the installer runs and basic flows (capture, record, annotations) work.

## Why a separate PR

These were uncovered while preparing a v0.1.0 release build. They're unrelated to the other in-flight PRs (README revision, docs), so isolating them keeps history clean and makes reverts easy if anything regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)