### PR TITLE
fix: hide FFmpeg/PowerShell console windows on Windows (v0.1.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "klipp",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "An open-source screenshot and screen recording tool with annotation support",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "klipp"
-version = "0.1.0"
+version = "0.1.1"
 description = "An open-source screenshot and screen recording tool with annotation support"
 authors = ["FuselabsAI"]
 edition = "2021"

--- a/src-tauri/src/commands/ffmpeg.rs
+++ b/src-tauri/src/commands/ffmpeg.rs
@@ -1,7 +1,21 @@
+use std::ffi::OsStr;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use tauri::{AppHandle, Manager};
+
+/// Build a `Command` that, on Windows, suppresses the console window FFmpeg/PowerShell
+/// would otherwise spawn alongside the GUI app. No-op on other platforms.
+pub fn hidden_command<S: AsRef<OsStr>>(program: S) -> Command {
+    let mut cmd = Command::new(program);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // CREATE_NO_WINDOW — prevents the child from getting its own console window.
+        cmd.creation_flags(0x0800_0000);
+    }
+    cmd
+}
 
 fn ffmpeg_dir(app: &AppHandle) -> Result<PathBuf, String> {
     let data_dir = app
@@ -34,7 +48,7 @@ pub fn check_ffmpeg(app: AppHandle) -> Result<bool, String> {
     if bundled.exists() {
         return Ok(true);
     }
-    match Command::new("ffmpeg").arg("-version").output() {
+    match hidden_command("ffmpeg").arg("-version").output() {
         Ok(output) => Ok(output.status.success()),
         Err(_) => Ok(false),
     }
@@ -67,7 +81,7 @@ pub async fn download_ffmpeg(app: AppHandle) -> Result<(), String> {
         zip_path.to_string_lossy()
     );
 
-    let download_status = Command::new("powershell.exe")
+    let download_status = hidden_command("powershell.exe")
         .args(["-NoProfile", "-Command", &download_script])
         .status()
         .map_err(|e| format!("Failed to start download: {}", e))?;
@@ -113,7 +127,7 @@ pub async fn download_ffmpeg(app: AppHandle) -> Result<(), String> {
         exe_path.to_string_lossy()
     );
 
-    let extract_output = Command::new("powershell.exe")
+    let extract_output = hidden_command("powershell.exe")
         .args(["-NoProfile", "-Command", &extract_script])
         .output()
         .map_err(|e| format!("Failed to extract FFmpeg: {}", e))?;
@@ -133,7 +147,7 @@ pub async fn download_ffmpeg(app: AppHandle) -> Result<(), String> {
         return Err("FFmpeg extraction failed — file not created.".into());
     }
 
-    let verify = Command::new(&exe_path)
+    let verify = hidden_command(&exe_path)
         .arg("-version")
         .output()
         .map_err(|e| format!("FFmpeg verification failed: {}", e))?;

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Stdio};
 use std::sync::Mutex;
 use tauri::{AppHandle, State};
 
@@ -40,7 +40,7 @@ impl RecordingState {
 #[tauri::command]
 pub fn list_webcams(app: AppHandle) -> Result<Vec<String>, String> {
     let ffmpeg_path = ffmpeg::get_ffmpeg_path_internal(&app)?;
-    let output = Command::new(&ffmpeg_path)
+    let output = ffmpeg::hidden_command(&ffmpeg_path)
         .args(["-list_devices", "true", "-f", "dshow", "-i", "dummy"])
         .output()
         .map_err(|e| format!("Failed to list devices: {}", e))?;
@@ -70,7 +70,7 @@ pub fn list_webcams(app: AppHandle) -> Result<Vec<String>, String> {
 #[tauri::command]
 pub fn list_audio_inputs(app: AppHandle) -> Result<Vec<String>, String> {
     let ffmpeg_path = ffmpeg::get_ffmpeg_path_internal(&app)?;
-    let output = Command::new(&ffmpeg_path)
+    let output = ffmpeg::hidden_command(&ffmpeg_path)
         .args(["-list_devices", "true", "-f", "dshow", "-i", "dummy"])
         .output()
         .map_err(|e| format!("Failed to list devices: {}", e))?;
@@ -264,7 +264,7 @@ pub fn start_recording(
         config.output_path.clone(),
     ]);
 
-    let child = Command::new(&ffmpeg_path)
+    let child = ffmpeg::hidden_command(&ffmpeg_path)
         .args(&args)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Klipp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.fuselabs.klipp",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Suppresses the visible console window that flashed alongside FFmpeg recording, device enumeration, and the PowerShell-driven FFmpeg downloader on Windows.
- Adds a small `hidden_command()` helper in `commands/ffmpeg.rs` that applies `CREATE_NO_WINDOW` (`0x0800_0000`) on Windows; no-op on other platforms.
- All seven `Command::new` spawn sites in `commands/ffmpeg.rs` and `commands/recording.rs` now go through the helper.
- Bumps version to **0.1.1** across `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`.

## Reported issue
After installing the v0.1.0 portable, recording the screen also opened a visible `ffmpeg.exe` console window in front of the GUI — distracting and unprofessional. Same window would have shown during the FFmpeg auto-download flow.

## Test plan
- [x] `cargo check` — clean (one pre-existing unused-var warning unrelated to this change)
- [x] `npm run tauri build` — produces `Klipp_0.1.1_x64-setup.exe`, `Klipp_0.1.1_x64_en-US.msi`, portable `klipp.exe`
- [ ] Install v0.1.1 portable → start a recording → confirm no FFmpeg console window appears
- [ ] Toggle the camera/MIC dropdowns → confirm device enumeration also runs silently
- [ ] On a fresh machine without FFmpeg, trigger Record → confirm the PowerShell download also runs hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)