### PR TITLE
docs: add Download links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A lightweight, native alternative to Microsoft Snipping Tool with real-time anno
 <!-- TODO: Drop a hero screenshot or demo GIF here to boost attention -->
 <!-- Example: <img src="docs/images/hero.gif" alt="Klipp demo" width="720" /> -->
 
+### [⬇ Download the latest release](https://github.com/alemhar/klipp/releases/latest)
+
 </div>
 
 ---
@@ -104,13 +106,17 @@ Existing screen tools each give up something. Klipp's goal is one small, fast, n
 
 ## 📦 Download & Getting Started
 
-<!-- TODO: Uncomment once a release installer is published
-### Install
-- [Windows (.exe installer)](https://github.com/alemhar/klipp/releases/latest)
-- [Portable ZIP](https://github.com/alemhar/klipp/releases/latest)
--->
+Grab the latest Windows build from the [Releases page](https://github.com/alemhar/klipp/releases/latest):
 
-Klipp is currently pre-release. The fastest way to try it today is to clone and run from source (see [Development](#-development)). Signed installers will be published to the [Releases page](https://github.com/alemhar/klipp/releases) when v0.2.0 ships.
+| Artifact | Best for |
+|---|---|
+| **`Klipp_<version>_x64-setup.exe`** (NSIS) | Most users — small wizard, Start-menu shortcut, clean uninstall |
+| **`Klipp_<version>_x64_en-US.msi`** | IT admins — Group Policy, Intune, SCCM deployments |
+| **`Klipp_<version>_x64-portable.exe`** | Power users — no installer, runs from any folder |
+
+> Builds are currently **unsigned**, so Windows SmartScreen may warn on first launch — click "More info → Run anyway". Code signing is on the roadmap.
+
+Prefer building from source? See [Development](#-development).
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a prominent **⬇ Download the latest release** link in the hero block right under the badges so first-time visitors see it above the fold.
- Replaces the outdated "currently pre-release" stub in the Download section with a real artifact table (NSIS installer, MSI, portable) and a brief SmartScreen note (until code signing lands).
- Filenames use a `<version>` placeholder so the README does not need to be edited every release.

## Why
v0.1.1 is now the first published release on GitHub. Previously the README had a TODO comment and a "currently pre-release" sentence that no longer matched reality.

## Test plan
- [x] Local diff reviewed — 12 insertions, 6 deletions, no formatting drift
- [ ] Render preview on GitHub looks correct
- [ ] Both download links resolve to https://github.com/alemhar/klipp/releases/latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)