### PR TITLE
refactor: change bundle identifier to com.zyntaxzo.klipp

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Screenshot capture, annotations, and all related tools work out of the box.
 
 If you accidentally click **Block** and later want to enable it, the **CAM** or **MIC** button in the title bar will turn amber and its tooltip will say "Camera/Microphone blocked — click for help re-enabling". Clicking it opens a dialog with two recovery steps:
 1. Check **Windows Settings → Privacy & Security → Camera** (or **Microphone**) is on for desktop apps.
-2. If still blocked, clear the WebView2 cache folder at `%LOCALAPPDATA%\com.fuselabs.klipp\EBWebView\` and relaunch Klipp to re-prompt.
+2. If still blocked, clear the WebView2 cache folder at `%LOCALAPPDATA%\com.zyntaxzo.klipp\EBWebView\` and relaunch Klipp to re-prompt.
 
 ---
 

--- a/docs/architecture/02-ffmpeg-auto-downloader.md
+++ b/docs/architecture/02-ffmpeg-auto-downloader.md
@@ -66,7 +66,7 @@ The binary lives at:
 <app_data_dir>/ffmpeg/ffmpeg.exe
 ```
 
-Where `<app_data_dir>` on Windows resolves to `%APPDATA%\com.fuselabs.klipp\ffmpeg\ffmpeg.exe` via Tauri's `app.path().app_data_dir()`. Keeping it in the app's data directory (not `Program Files` or similar) means:
+Where `<app_data_dir>` on Windows resolves to `%APPDATA%\com.zyntaxzo.klipp\ffmpeg\ffmpeg.exe` via Tauri's `app.path().app_data_dir()`. Keeping it in the app's data directory (not `Program Files` or similar) means:
 
 - No elevated permissions required.
 - Cleanly uninstalls when the user removes the app directory.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Klipp",
   "version": "0.1.1",
-  "identifier": "com.fuselabs.klipp",
+  "identifier": "com.zyntaxzo.klipp",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",

--- a/src/components/recording/PermissionBlockedModal.tsx
+++ b/src/components/recording/PermissionBlockedModal.tsx
@@ -140,7 +140,7 @@ export function PermissionBlockedModal({
                 whiteSpace: "nowrap",
               }}
             >
-              %LOCALAPPDATA%\com.fuselabs.klipp\EBWebView\
+              %LOCALAPPDATA%\com.zyntaxzo.klipp\EBWebView\
             </div>
           </li>
           <li>


### PR DESCRIPTION
## Summary
- Switches the app's reverse-DNS bundle identifier from `com.fuselabs.klipp` → `com.zyntaxzo.klipp` to align with the **Zyntax Zo** brand under which Klipp is being released.
- Touches **4 files**: the `tauri.conf.json` source-of-truth plus three docs/UI references to `%APPDATA%`/`%LOCALAPPDATA%` paths.

## Why now
The identifier drives:
- the per-app data folder (`%APPDATA%\<id>\`, where the auto-downloaded FFmpeg lives)
- WebView2 storage (`%LOCALAPPDATA%\<id>\EBWebView\`, where camera/mic permissions live)
- Windows installer upgrade codes (Tauri derives them from the identifier)

Doing the rename now — while v0.1.1's install base is still essentially zero — keeps the migration cost free. The longer we wait, the more existing users will need to (a) re-grant camera/mic permissions, (b) re-download FFmpeg, and (c) manually uninstall the old `com.fuselabs.klipp` entry from "Apps & Features".

## Migration impact (for whoever does install v0.1.1 today)
After they upgrade to the next release built off this change:
- One-time FFmpeg re-download (~30 MB)
- One-time camera + microphone re-prompt
- They'll see two Klipp entries in "Apps & Features" until the old one is uninstalled

This impact should be called out in the v0.2.0 release notes.

## Verification
- `npx tsc --noEmit` → clean
- `cargo check` → clean (only the pre-existing `next_input_idx` `unused_assignments` warning, unrelated to this change)
- `grep -r "com.fuselabs.klipp"` → no matches remaining

## Test plan
- [ ] Build NSIS / MSI / portable from this branch and confirm app launches normally
- [ ] Verify FFmpeg downloads to `%APPDATA%\com.zyntaxzo.klipp\ffmpeg\`
- [ ] Verify WebView2 cache lands at `%LOCALAPPDATA%\com.zyntaxzo.klipp\EBWebView\`
- [ ] Confirm camera/mic permission re-prompt happens on first run

## Out of scope
- Version bump → keep on this branch as a separate commit, or bump alongside v0.2.0 when shipping.
- Domain ownership of `zyntaxzo.com` — recommend acquiring it (~$10/yr) so the reverse-DNS namespace is genuinely controlled, but not blocking this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)