### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "klipp",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "An open-source screenshot and screen recording tool with annotation support",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "klipp"
-version = "0.1.1"
+version = "0.1.2"
 description = "An open-source screenshot and screen recording tool with annotation support"
 authors = ["FuselabsAI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Klipp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.zyntaxzo.klipp",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Bumps version to **0.1.2** across `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`.
- First release built under the new `com.zyntaxzo.klipp` bundle identifier (PR #15).

## Why a point release for an identifier change
There are no real users of v0.1.1 yet, so the migration cost (FFmpeg re-download, permission re-prompt, manual uninstall of the old `com.fuselabs.klipp` entry) is essentially zero. Doing it now keeps v0.2.0 free for the next real feature drop.

## Artifacts
Built and copied to `D:\FuselabsAI\Projects\Klipp\Releases\`:
- `Klipp_0.1.2_x64-setup.exe` (NSIS, ~4.5 MB)
- `Klipp_0.1.2_x64_en-US.msi` (~6.7 MB)
- `Klipp_0.1.2_x64-portable.exe` (~20 MB)

## Test plan
- [ ] Install the v0.1.2 portable on a clean machine
- [ ] Confirm app data lands at `%APPDATA%\com.zyntaxzo.klipp\` (not `com.fuselabs.klipp\`)
- [ ] Confirm WebView2 cache lands at `%LOCALAPPDATA%\com.zyntaxzo.klipp\EBWebView\`
- [ ] Trigger Record → confirm FFmpeg downloads to the new path and no console window flashes
- [ ] Camera + microphone re-prompt fires (since the WebView2 cache changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)