### PR TITLE
feat: Plan 12 — compact pill-mode launch

### DIFF
--- a/docs/plans/12-compact-pill-launch-mode.md
+++ b/docs/plans/12-compact-pill-launch-mode.md
@@ -1,6 +1,6 @@
 # Plan 12 — Compact Pill-Mode Launch
 
-> **Status**: 🚧 Future release. App currently launches in full-size window which obstructs the view the user wants to capture.
+> **Status**: ✅ Shipped 2026-04-21 on branch `feat/pill-mode-launch`. Implementation diverged from the spec in two notable ways: (1) the Options popover and Mode/Delay dropdowns use **native OS popup menus** (via a Tauri `show_pill_menu` command) instead of DOM-based dropdowns — they paint outside the pill window the way Microsoft Snipping Tool does, with no window resize hack. (2) Post-capture window is sized to fit the captured region + chrome (Snipping Tool behaviour) rather than expanding to a fixed full-window size. The TitleBar in window mode was also re-ordered to match the pill's nav sequence (New → Mode → Delay → Record → Cancel) for cross-mode consistency, with CAM/MIC/SYS/Theme/Settings/Collapse appended after.
 
 ## Context
 

--- a/docs/plans/STATUS.md
+++ b/docs/plans/STATUS.md
@@ -2,7 +2,7 @@
 
 Quick at-a-glance status of every plan in [`docs/plans/`](.). For execution order, descriptions, and dependencies, see [README.md](./README.md). For full implementation detail, open the individual plan file.
 
-**Summary:** 7 shipped · 2 partially shipped · 5 pending · **12 total**
+**Summary:** 8 shipped · 2 partially shipped · 4 pending · **12 total**
 
 | # | Plan | Status | Notes |
 |---|------|--------|-------|
@@ -17,7 +17,7 @@ Quick at-a-glance status of every plan in [`docs/plans/`](.). For execution orde
 | 09 | [Window Capture Mode](./09-window-capture-mode.md) | 🚧 Pending | "Window" option in capture-mode dropdown is currently a no-op |
 | 10 | [Proactive FFmpeg First-Run UX](./10-ffmpeg-proactive-first-run-ux.md) | 🚧 Pending | Minimal fix (spinner + auto-proceed) shipped; proactive install banner pending |
 | 11 | [WebView2 Camera Permission Intercept](./11-webview2-permission-intercept.md) | 🚧 Pending | Recovery modal + amber CAM icon shipped; native Klipp prompt instead of WebView2 dialog still owed |
-| 12 | [Compact Pill-Mode Launch](./12-compact-pill-launch-mode.md) | 🚧 Pending | Snipping-Tool-style launch UX; planned for next feature release |
+| 12 | [Compact Pill-Mode Launch](./12-compact-pill-launch-mode.md) | ✅ Shipped | Two-row pill (560×90) with native OS popup menus for Mode/Delay/Options. Auto-resizes to fit captured region after Snip. TitleBar nav reordered to match pill sequence. |
 
 ## Legend
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -43,6 +43,7 @@
     "core:window:allow-is-fullscreen",
     "core:window:allow-set-size",
     "core:window:allow-set-position",
+    "core:window:allow-set-resizable",
     "core:window:allow-outer-size",
     "core:window:allow-outer-position",
     "core:window:allow-minimize",

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,5 +3,6 @@ pub mod clipboard;
 pub mod ffmpeg;
 pub mod file_io;
 pub mod overlay;
+pub mod pill_menu;
 pub mod recording;
 pub mod settings;

--- a/src-tauri/src/commands/pill_menu.rs
+++ b/src-tauri/src/commands/pill_menu.rs
@@ -1,0 +1,153 @@
+use tauri::{
+    menu::{CheckMenuItem, ContextMenu, Menu, MenuItem, PredefinedMenuItem},
+    AppHandle, LogicalPosition, Wry,
+};
+
+/// Show a native popup menu for the pill UI. Using the OS menu means the
+/// dropdown paints *outside* the pill window, matching Microsoft Snipping
+/// Tool's behaviour — no window resize hack needed. Item IDs are prefixed by
+/// the menu kind (e.g. "pill-mode:rectangular") so the global menu-event
+/// handler can route the selection to the correct frontend handler via a
+/// `pill-menu-selected` event.
+#[tauri::command]
+pub fn show_pill_menu(
+    app: AppHandle,
+    window: tauri::WebviewWindow,
+    kind: String,
+    x: f64,
+    y: f64,
+    current_mode: String,
+    current_delay: u32,
+    mic_enabled: bool,
+    webcam_enabled: bool,
+) -> Result<(), String> {
+    let menu = match kind.as_str() {
+        "mode" => build_mode_menu(&app, &current_mode)?,
+        "delay" => build_delay_menu(&app, current_delay)?,
+        "options" => build_options_menu(&app, mic_enabled, webcam_enabled)?,
+        other => return Err(format!("unknown pill menu kind: {}", other)),
+    };
+    ContextMenu::popup_at(&menu, window.as_ref().window(), LogicalPosition::new(x, y))
+        .map_err(|e| format!("Failed to popup menu: {}", e))?;
+    Ok(())
+}
+
+fn build_mode_menu(app: &AppHandle, current: &str) -> Result<Menu<Wry>, String> {
+    let menu = Menu::new(app).map_err(|e| e.to_string())?;
+    let selection = CheckMenuItem::with_id(
+        app,
+        "pill-mode:rectangular",
+        "Selection",
+        true,
+        current == "rectangular",
+        None::<&str>,
+    )
+    .map_err(|e| e.to_string())?;
+    let fullscreen = CheckMenuItem::with_id(
+        app,
+        "pill-mode:fullscreen",
+        "Fullscreen",
+        true,
+        current == "fullscreen",
+        None::<&str>,
+    )
+    .map_err(|e| e.to_string())?;
+    let window_item = CheckMenuItem::with_id(
+        app,
+        "pill-mode:window",
+        "Window (coming soon)",
+        false,
+        false,
+        None::<&str>,
+    )
+    .map_err(|e| e.to_string())?;
+    menu.append(&selection).map_err(|e| e.to_string())?;
+    menu.append(&fullscreen).map_err(|e| e.to_string())?;
+    menu.append(&window_item).map_err(|e| e.to_string())?;
+    Ok(menu)
+}
+
+fn build_delay_menu(app: &AppHandle, current: u32) -> Result<Menu<Wry>, String> {
+    let menu = Menu::new(app).map_err(|e| e.to_string())?;
+    for (val, label) in [
+        (0u32, "No delay"),
+        (3, "3 seconds"),
+        (5, "5 seconds"),
+        (10, "10 seconds"),
+    ] {
+        let item = CheckMenuItem::with_id(
+            app,
+            &format!("pill-delay:{}", val),
+            label,
+            true,
+            current == val,
+            None::<&str>,
+        )
+        .map_err(|e| e.to_string())?;
+        menu.append(&item).map_err(|e| e.to_string())?;
+    }
+    Ok(menu)
+}
+
+fn build_options_menu(
+    app: &AppHandle,
+    mic_enabled: bool,
+    webcam_enabled: bool,
+) -> Result<Menu<Wry>, String> {
+    let menu = Menu::new(app).map_err(|e| e.to_string())?;
+
+    // Audio header (disabled "item" used as a visual label)
+    let audio_header =
+        MenuItem::with_id(app, "pill-opts:__audio-header", "Audio sources", false, None::<&str>)
+            .map_err(|e| e.to_string())?;
+    menu.append(&audio_header).map_err(|e| e.to_string())?;
+
+    let mic = CheckMenuItem::with_id(
+        app,
+        "pill-opts:mic",
+        "Microphone",
+        true,
+        mic_enabled,
+        None::<&str>,
+    )
+    .map_err(|e| e.to_string())?;
+    menu.append(&mic).map_err(|e| e.to_string())?;
+
+    let sys =
+        CheckMenuItem::with_id(app, "pill-opts:sys", "System audio (coming soon)", false, false, None::<&str>)
+            .map_err(|e| e.to_string())?;
+    menu.append(&sys).map_err(|e| e.to_string())?;
+
+    let sep1 = PredefinedMenuItem::separator(app).map_err(|e| e.to_string())?;
+    menu.append(&sep1).map_err(|e| e.to_string())?;
+
+    // Webcam header
+    let webcam_header =
+        MenuItem::with_id(app, "pill-opts:__webcam-header", "Webcam", false, None::<&str>)
+            .map_err(|e| e.to_string())?;
+    menu.append(&webcam_header).map_err(|e| e.to_string())?;
+
+    let webcam = CheckMenuItem::with_id(
+        app,
+        "pill-opts:webcam",
+        "Webcam overlay",
+        true,
+        webcam_enabled,
+        None::<&str>,
+    )
+    .map_err(|e| e.to_string())?;
+    menu.append(&webcam).map_err(|e| e.to_string())?;
+
+    let sep2 = PredefinedMenuItem::separator(app).map_err(|e| e.to_string())?;
+    menu.append(&sep2).map_err(|e| e.to_string())?;
+
+    let prefs = MenuItem::with_id(app, "pill-opts:prefs", "Preferences…", true, None::<&str>)
+        .map_err(|e| e.to_string())?;
+    menu.append(&prefs).map_err(|e| e.to_string())?;
+
+    let quit = MenuItem::with_id(app, "pill-opts:quit", "Quit Klipp", true, None::<&str>)
+        .map_err(|e| e.to_string())?;
+    menu.append(&quit).map_err(|e| e.to_string())?;
+
+    Ok(menu)
+}

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -3,6 +3,19 @@ use std::fs;
 use std::path::PathBuf;
 use tauri::{AppHandle, Manager};
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowBounds {
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+}
+
+fn default_launch_mode() -> String {
+    "pill".to_string()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppSettings {
@@ -14,6 +27,13 @@ pub struct AppSettings {
     pub capture_shortcut: String,
     pub snip_outline: bool,
     pub snip_outline_color: String,
+
+    #[serde(default = "default_launch_mode")]
+    pub launch_mode: String,
+    #[serde(default)]
+    pub pill_bounds: Option<WindowBounds>,
+    #[serde(default)]
+    pub full_bounds: Option<WindowBounds>,
 }
 
 impl Default for AppSettings {
@@ -27,6 +47,9 @@ impl Default for AppSettings {
             capture_shortcut: "Ctrl+Shift+S".into(),
             snip_outline: false,
             snip_outline_color: "#FF0000".into(),
+            launch_mode: default_launch_mode(),
+            pill_bounds: None,
+            full_bounds: None,
         }
     }
 }
@@ -41,9 +64,11 @@ fn settings_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(config_dir.join("settings.json"))
 }
 
-#[tauri::command]
-pub fn get_settings(app: AppHandle) -> Result<AppSettings, String> {
-    let path = settings_path(&app)?;
+/// Read settings from disk. Used by the Tauri setup hook to apply initial
+/// window bounds before the UI becomes visible. Mirrors the `get_ffmpeg_path_internal`
+/// pattern — same I/O as the command but callable directly from Rust.
+pub fn get_settings_internal(app: &AppHandle) -> Result<AppSettings, String> {
+    let path = settings_path(app)?;
     if path.exists() {
         let content =
             fs::read_to_string(&path).map_err(|e| format!("Failed to read settings: {}", e))?;
@@ -51,6 +76,11 @@ pub fn get_settings(app: AppHandle) -> Result<AppSettings, String> {
     } else {
         Ok(AppSettings::default())
     }
+}
+
+#[tauri::command]
+pub fn get_settings(app: AppHandle) -> Result<AppSettings, String> {
+    get_settings_internal(&app)
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,43 @@ mod commands;
 mod settings;
 mod tray;
 
-use tauri::Manager;
+use tauri::{AppHandle, Emitter, LogicalPosition, LogicalSize, Manager};
+
+/// Apply the persisted window mode (pill / full) + bounds before the main
+/// window is shown. Defaults to a 560x90 pill centered at the top of the
+/// primary monitor on first run. Falls back silently on any error — the window
+/// will still become visible with its tauri.conf.json defaults.
+fn apply_initial_window_state(app: &AppHandle) {
+    let settings = commands::settings::get_settings_internal(app).unwrap_or_default();
+    let Some(win) = app.get_webview_window("main") else {
+        return;
+    };
+
+    let is_pill = settings.launch_mode == "pill";
+    let (default_w, default_h): (u32, u32) = if is_pill { (560, 90) } else { (1200, 800) };
+    let bounds_opt = if is_pill { settings.pill_bounds } else { settings.full_bounds };
+    let (width, height) = bounds_opt
+        .map(|b| (b.width, b.height))
+        .unwrap_or((default_w, default_h));
+
+    let _ = win.set_resizable(!is_pill);
+    let _ = win.set_size(LogicalSize::new(width as f64, height as f64));
+
+    if let Some(b) = bounds_opt {
+        let _ = win.set_position(LogicalPosition::new(b.x as f64, b.y as f64));
+    } else if is_pill {
+        // Center pill at top of primary monitor. Fall back to a sensible default
+        // if the monitor can't be resolved.
+        if let Ok(Some(m)) = win.primary_monitor() {
+            let scale = m.scale_factor();
+            let logical_w = m.size().width as f64 / scale;
+            let x = ((logical_w - width as f64) / 2.0).round() as i32;
+            let _ = win.set_position(LogicalPosition::new(x as f64, 10.0));
+        }
+    }
+
+    let _ = win.show();
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -17,7 +53,16 @@ pub fn run() {
         .manage(commands::recording::RecordingState::new())
         .setup(|app| {
             tray::create_tray(app)?;
+            apply_initial_window_state(app.handle());
             Ok(())
+        })
+        .on_menu_event(|app, event| {
+            // Forward pill-menu selections (ids prefixed "pill-") back to the
+            // frontend so the PillModeBar can update React state.
+            let id = event.id().as_ref();
+            if id.starts_with("pill-") {
+                let _ = app.emit("pill-menu-selected", id.to_string());
+            }
         })
         .on_window_event(|window, event| {
             // When the main window is closed, clean up overlay and mouse hook
@@ -52,6 +97,7 @@ pub fn run() {
             commands::overlay::set_overlay_interactive,
             commands::overlay::start_mouse_hook,
             commands::overlay::stop_mouse_hook,
+            commands::pill_menu::show_pill_menu,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,8 +13,10 @@
     "windows": [
       {
         "title": "Klipp",
-        "width": 800,
-        "height": 600
+        "width": 560,
+        "height": 90,
+        "resizable": false,
+        "visible": false
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useCallback, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { TitleBar } from "./components/layout/TitleBar";
+import { PillModeBar } from "./components/layout/PillModeBar";
 import { Toolbar } from "./components/layout/Toolbar";
 import { StatusBar } from "./components/layout/StatusBar";
 import { ToolOptionsBar } from "./components/layout/ToolOptionsBar";
@@ -17,6 +18,7 @@ import { useCanvasStore } from "./stores/canvasStore";
 import type { TextObject } from "./types/canvas";
 import { useSettingsStore } from "./stores/settingsStore";
 import { useRecordingStore } from "./stores/recordingStore";
+import { useWindowModeStore } from "./stores/windowModeStore";
 import { useGlobalShortcut } from "./hooks/useGlobalShortcut";
 
 function App() {
@@ -46,17 +48,22 @@ function App() {
     useUIStore.getState().setActiveTool("select");
   };
   const { settings, isLoaded, loadSettings } = useSettingsStore();
+  const windowMode = useWindowModeStore((s) => s.mode);
 
   // Load settings + enumerate audio inputs on mount
   useEffect(() => {
-    loadSettings();
-    useRecordingStore.getState().loadAudioInputs();
+    (async () => {
+      await loadSettings();
+      useWindowModeStore.getState().initFromSettings();
+      useRecordingStore.getState().loadAudioInputs();
 
-    // Apply theme
-    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    const theme = settings.theme === "system" ? (prefersDark ? "dark" : "light") : settings.theme;
-    document.documentElement.setAttribute("data-theme", theme);
-    useUIStore.getState().setResolvedTheme(theme);
+      // Apply theme
+      const { settings: s } = useSettingsStore.getState();
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      const theme = s.theme === "system" ? (prefersDark ? "dark" : "light") : s.theme;
+      document.documentElement.setAttribute("data-theme", theme);
+      useUIStore.getState().setResolvedTheme(theme);
+    })();
   }, []);
 
   // Handle capture shortcut — context-aware:
@@ -144,11 +151,17 @@ function App() {
         width: "100vw",
       }}
     >
-      <TitleBar />
-      <Toolbar />
-      <ToolOptionsBar />
-      <AnnotationCanvas />
-      <StatusBar />
+      {windowMode === "pill" ? (
+        <PillModeBar />
+      ) : (
+        <>
+          <TitleBar />
+          <Toolbar />
+          <ToolOptionsBar />
+          <AnnotationCanvas />
+          <StatusBar />
+        </>
+      )}
 
       {isDelaying && (
         <DelayTimer

--- a/src/components/capture/CaptureOverlay.tsx
+++ b/src/components/capture/CaptureOverlay.tsx
@@ -5,6 +5,7 @@ import { useCaptureStore } from "../../stores/captureStore";
 import { useUIStore } from "../../stores/uiStore";
 import { useSettingsStore } from "../../stores/settingsStore";
 import { useCanvasStore } from "../../stores/canvasStore";
+import { useWindowModeStore } from "../../stores/windowModeStore";
 import { copyImageToClipboard } from "../../lib/export";
 import type { CaptureResult } from "../../types/capture";
 
@@ -42,6 +43,12 @@ export function CaptureOverlay() {
   const finishCapture = useCallback(
     async (result: CaptureResult) => {
       await restoreMainWindow();
+      // If launched as a pill, resize the window to fit the captured region
+      // plus annotation chrome — mirrors Snipping Tool's post-capture UX.
+      const { mode: windowMode, expandToCaptureSize } = useWindowModeStore.getState();
+      if (windowMode === "pill") {
+        await expandToCaptureSize(result.width, result.height);
+      }
       setIsCaptureMode(false);
       useCanvasStore.getState().clearAll();
       setCapturedImage(result);
@@ -74,6 +81,10 @@ export function CaptureOverlay() {
           // Restore and show result without overlay
           await mainWindow.show();
           await mainWindow.setFocus();
+          const { mode: windowMode, expandToCaptureSize } = useWindowModeStore.getState();
+          if (windowMode === "pill") {
+            await expandToCaptureSize(pngResult.width, pngResult.height);
+          }
           setIsCaptureMode(false);
           useCanvasStore.getState().clearAll();
           setCapturedImage(pngResult);

--- a/src/components/layout/PillModeBar.tsx
+++ b/src/components/layout/PillModeBar.tsx
@@ -1,0 +1,326 @@
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { listen } from "@tauri-apps/api/event";
+import {
+  Scissors,
+  Monitor,
+  Maximize,
+  Square,
+  Clock,
+  Video,
+  X,
+  MoreHorizontal,
+  ChevronUp,
+  ChevronDown,
+  Loader2,
+} from "lucide-react";
+import { useUIStore } from "../../stores/uiStore";
+import { useCaptureStore } from "../../stores/captureStore";
+import { useRecordingStore } from "../../stores/recordingStore";
+import { useWindowModeStore } from "../../stores/windowModeStore";
+import { useRecordFlow } from "../../hooks/useRecordFlow";
+import { useMediaPermission } from "../../hooks/useMediaPermission";
+import { PermissionBlockedModal } from "../recording/PermissionBlockedModal";
+import type { CaptureMode, DelayOption } from "../../types/capture";
+
+const CAPTURE_MODE_ICONS: Record<CaptureMode, React.ReactNode> = {
+  rectangular: <Square size={14} />,
+  fullscreen: <Maximize size={14} />,
+  window: <Monitor size={14} />,
+  freeform: <Square size={14} />,
+};
+
+const DELAY_LABELS: Record<number, string> = {
+  0: "Delay",
+  3: "3 s",
+  5: "5 s",
+  10: "10 s",
+};
+
+const ROW1_BTN: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+  height: 32,
+  padding: "0 10px",
+  borderRadius: 6,
+  border: "none",
+  cursor: "pointer",
+  backgroundColor: "transparent",
+  color: "var(--text-primary)",
+  fontSize: 12,
+};
+
+export function PillModeBar() {
+  const { setIsCaptureMode, isCaptureMode, setShowSettings } = useUIStore();
+  const { mode, delay, setMode, setDelay } = useCaptureStore();
+  const {
+    isRecording,
+    stopRecording,
+    webcamEnabled,
+    setWebcamEnabled,
+    micAudioEnabled,
+    setMicAudioEnabled,
+  } = useRecordingStore();
+  const { expandToFull } = useWindowModeStore();
+  const record = useRecordFlow();
+  const cameraPermission = useMediaPermission("camera");
+  const microphonePermission = useMediaPermission("microphone");
+  const [blockedModal, setBlockedModal] = useState<"camera" | "microphone" | null>(null);
+
+  // Keep latest state available to the native-menu event listener, which
+  // runs outside React's render cycle.
+  const stateRef = useRef({
+    setMode,
+    setDelay,
+    setMicAudioEnabled,
+    setWebcamEnabled,
+    setShowSettings,
+    expandToFull,
+    setBlockedModal,
+    cameraPermission,
+    microphonePermission,
+  });
+  stateRef.current = {
+    setMode,
+    setDelay,
+    setMicAudioEnabled,
+    setWebcamEnabled,
+    setShowSettings,
+    expandToFull,
+    setBlockedModal,
+    cameraPermission,
+    microphonePermission,
+  };
+
+  useEffect(() => {
+    const unlistenPromise = listen<string>("pill-menu-selected", (event) => {
+      const id = event.payload;
+      const s = stateRef.current;
+      if (id.startsWith("pill-mode:")) {
+        s.setMode(id.substring("pill-mode:".length) as CaptureMode);
+      } else if (id.startsWith("pill-delay:")) {
+        const n = parseInt(id.substring("pill-delay:".length), 10);
+        s.setDelay(n as DelayOption);
+      } else if (id === "pill-opts:mic") {
+        const currentlyOn = useRecordingStore.getState().micAudioEnabled;
+        if (!currentlyOn && s.microphonePermission === "denied") {
+          s.setBlockedModal("microphone");
+        } else {
+          s.setMicAudioEnabled(!currentlyOn);
+        }
+      } else if (id === "pill-opts:webcam") {
+        const currentlyOn = useRecordingStore.getState().webcamEnabled;
+        if (!currentlyOn && s.cameraPermission === "denied") {
+          s.setBlockedModal("camera");
+        } else {
+          s.setWebcamEnabled(!currentlyOn);
+        }
+      } else if (id === "pill-opts:prefs") {
+        (async () => {
+          await s.expandToFull();
+          s.setShowSettings(true);
+        })();
+      } else if (id === "pill-opts:quit") {
+        getCurrentWindow().close();
+      }
+    });
+    return () => {
+      unlistenPromise.then((fn) => fn());
+    };
+  }, []);
+
+  const showPillMenu = async (kind: "mode" | "delay" | "options", btn: HTMLElement) => {
+    const rect = btn.getBoundingClientRect();
+    await invoke("show_pill_menu", {
+      kind,
+      x: rect.left,
+      y: rect.bottom + 2,
+      currentMode: mode,
+      currentDelay: delay,
+      micEnabled: micAudioEnabled,
+      webcamEnabled,
+    }).catch((e) => console.error("show_pill_menu failed:", e));
+  };
+
+  const handleNew = () => {
+    if (isCaptureMode || isRecording) return;
+    setIsCaptureMode(true);
+  };
+
+  const cancelActive = isCaptureMode || isRecording;
+  const handleCancel = () => {
+    if (isRecording) stopRecording();
+    else if (isCaptureMode) setIsCaptureMode(false);
+  };
+
+  const helperText = isRecording
+    ? "Recording in progress — press Ctrl+Shift+S to stop."
+    : isCaptureMode
+    ? "Drag to select the area you want to capture, or press Esc to cancel."
+    : "Select the snip mode using the Mode button or click the New button.";
+
+  return (
+    <div
+      data-tauri-drag-region
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: "100vw",
+        height: "100vh",
+        backgroundColor: "var(--bg-toolbar)",
+        borderBottom: "1px solid var(--border-color)",
+        userSelect: "none",
+      }}
+    >
+      {/* Row 1 — action bar */}
+      <div
+        data-tauri-drag-region
+        style={{
+          display: "flex",
+          alignItems: "center",
+          padding: "0 8px",
+          height: 56,
+          gap: 2,
+        }}
+      >
+        {/* ✂ New */}
+        <button
+          title="New Capture (Ctrl+Shift+S)"
+          onClick={handleNew}
+          disabled={isCaptureMode || isRecording}
+          style={{
+            ...ROW1_BTN,
+            color: isCaptureMode || isRecording ? "var(--text-secondary)" : "#dc2626",
+            fontWeight: 600,
+          }}
+        >
+          <Scissors size={16} />
+          <span>New</span>
+        </button>
+
+        {/* ▾ Mode — native popup menu */}
+        <button
+          title="Mode"
+          onClick={(e) => showPillMenu("mode", e.currentTarget)}
+          style={ROW1_BTN}
+        >
+          {CAPTURE_MODE_ICONS[mode]}
+          <span>Mode</span>
+          <ChevronDown size={12} />
+        </button>
+
+        {/* ⏱ Delay — native popup menu */}
+        <button
+          title="Delay"
+          onClick={(e) => showPillMenu("delay", e.currentTarget)}
+          style={ROW1_BTN}
+        >
+          <Clock size={14} />
+          <span>{DELAY_LABELS[delay] ?? "Delay"}</span>
+          <ChevronDown size={12} />
+        </button>
+
+        {/* ⏺ Record */}
+        <button
+          title={
+            record.isInstallingFfmpeg
+              ? "Installing FFmpeg... (one-time ~30MB download)"
+              : isRecording
+              ? "Recording..."
+              : "Screen Record"
+          }
+          onClick={record.onClick}
+          disabled={record.isInstallingFfmpeg || isCaptureMode}
+          style={{
+            ...ROW1_BTN,
+            color: isRecording
+              ? "#FF3B30"
+              : record.isInstallingFfmpeg
+              ? "#f59e0b"
+              : "var(--text-primary)",
+            backgroundColor: isRecording
+              ? "rgba(255,59,48,0.1)"
+              : record.isInstallingFfmpeg
+              ? "rgba(251,191,36,0.1)"
+              : "transparent",
+            cursor: isRecording
+              ? "default"
+              : record.isInstallingFfmpeg
+              ? "wait"
+              : "pointer",
+          }}
+        >
+          {record.isInstallingFfmpeg ? (
+            <Loader2 size={14} style={{ animation: "klipp-spin 1s linear infinite" }} />
+          ) : (
+            <Video size={14} />
+          )}
+          <span>Record</span>
+        </button>
+        <style>{`@keyframes klipp-spin { to { transform: rotate(360deg); } }`}</style>
+
+        {/* ✕ Cancel */}
+        <button
+          title={cancelActive ? "Cancel" : "Nothing to cancel"}
+          onClick={handleCancel}
+          disabled={!cancelActive}
+          style={{
+            ...ROW1_BTN,
+            color: cancelActive ? "var(--text-primary)" : "var(--text-secondary)",
+            cursor: cancelActive ? "pointer" : "default",
+            opacity: cancelActive ? 1 : 0.5,
+          }}
+        >
+          <X size={14} />
+          <span>Cancel</span>
+        </button>
+
+        {/* Spacer */}
+        <div style={{ flex: 1 }} />
+
+        {/* ⋯ Options — native popup menu */}
+        <button
+          title="Options"
+          onClick={(e) => showPillMenu("options", e.currentTarget)}
+          style={{ ...ROW1_BTN, padding: 0, width: 32, justifyContent: "center" }}
+        >
+          <MoreHorizontal size={16} />
+        </button>
+
+        {/* ⤢ Expand */}
+        <button
+          title="Expand to full window"
+          onClick={() => expandToFull()}
+          style={{ ...ROW1_BTN, padding: 0, width: 32, justifyContent: "center" }}
+        >
+          <ChevronUp size={16} />
+        </button>
+      </div>
+
+      {/* Row 2 — helper text (fixed height so the pill doesn't reflow) */}
+      <div
+        data-tauri-drag-region
+        style={{
+          height: 34,
+          display: "flex",
+          alignItems: "center",
+          padding: "0 12px",
+          fontSize: 12,
+          color: "var(--text-secondary)",
+          borderTop: "1px solid var(--border-color)",
+        }}
+      >
+        {helperText}
+      </div>
+
+      {blockedModal && (
+        <PermissionBlockedModal
+          device={blockedModal}
+          onClose={() => setBlockedModal(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/TitleBar.tsx
+++ b/src/components/layout/TitleBar.tsx
@@ -1,132 +1,162 @@
 import {
-  Camera,
+  Scissors,
   Settings,
   Moon,
   Sun,
   Square,
   Maximize,
-  Timer,
+  Monitor,
+  Minimize2,
+  Clock,
   ChevronDown,
   Video,
   Loader2,
+  X,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { useUIStore } from "../../stores/uiStore";
 import { useCaptureStore } from "../../stores/captureStore";
 import { useRecordingStore } from "../../stores/recordingStore";
+import { useWindowModeStore } from "../../stores/windowModeStore";
+import { useRecordFlow } from "../../hooks/useRecordFlow";
 import { AudioLevelIndicator } from "../recording/AudioLevelIndicator";
 import { PermissionBlockedModal } from "../recording/PermissionBlockedModal";
 import { useMediaPermission } from "../../hooks/useMediaPermission";
 import { APP_NAME } from "../../lib/constants";
 import type { CaptureMode, DelayOption } from "../../types/capture";
 
-const CAPTURE_MODES: {
-  mode: CaptureMode;
-  label: string;
-  icon: React.ReactNode;
-  disabled?: boolean;
-  disabledReason?: string;
-}[] = [
-  { mode: "rectangular", label: "Selection", icon: <Square size={14} /> },
-  { mode: "fullscreen", label: "Fullscreen", icon: <Maximize size={14} /> },
-  {
-    mode: "window",
-    label: "Window",
-    icon: <Square size={14} />,
-    disabled: true,
-    disabledReason:
-      "Window capture — coming in a future release.",
-  },
-];
+const CAPTURE_MODE_ICONS: Record<CaptureMode, React.ReactNode> = {
+  rectangular: <Square size={14} />,
+  fullscreen: <Maximize size={14} />,
+  window: <Monitor size={14} />,
+  freeform: <Square size={14} />,
+};
 
-const DELAY_OPTIONS: { value: DelayOption; label: string }[] = [
-  { value: 0, label: "No delay" },
-  { value: 3, label: "3 seconds" },
-  { value: 5, label: "5 seconds" },
-  { value: 10, label: "10 seconds" },
-];
+const DELAY_LABELS: Record<number, string> = {
+  0: "Delay",
+  3: "3 s",
+  5: "5 s",
+  10: "10 s",
+};
 
-function DropdownButton({
-  label,
-  icon,
-  children,
-}: {
-  label: string;
-  icon: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  const [open, setOpen] = useState(false);
+const NAV_BTN: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+  height: 30,
+  padding: "0 10px",
+  borderRadius: 6,
+  border: "none",
+  cursor: "pointer",
+  backgroundColor: "transparent",
+  color: "var(--text-primary)",
+  fontSize: 12,
+};
 
-  return (
-    <div style={{ position: "relative" }}>
-      <button
-        title={label}
-        onClick={() => setOpen(!open)}
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 2,
-          height: 28,
-          padding: "0 6px",
-          borderRadius: 6,
-          border: "none",
-          cursor: "pointer",
-          backgroundColor: "transparent",
-          color: "var(--text-primary)",
-          fontSize: 12,
-        }}
-      >
-        {icon}
-        <ChevronDown size={12} />
-      </button>
-      {open && (
-        <>
-          <div
-            style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, zIndex: 99 }}
-            onClick={() => setOpen(false)}
-          />
-          <div
-            style={{
-              position: "absolute",
-              top: "100%",
-              left: 0,
-              marginTop: 4,
-              backgroundColor: "var(--bg-primary)",
-              border: "1px solid var(--border-color)",
-              borderRadius: 8,
-              padding: 4,
-              minWidth: 140,
-              zIndex: 100,
-              boxShadow: "0 4px 16px rgba(0,0,0,0.15)",
-            }}
-            onClick={() => setOpen(false)}
-          >
-            {children}
-          </div>
-        </>
-      )}
-    </div>
-  );
-}
+const ICON_BTN: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 30,
+  height: 30,
+  borderRadius: 6,
+  border: "none",
+  cursor: "pointer",
+  backgroundColor: "transparent",
+  color: "var(--text-primary)",
+};
 
 export function TitleBar() {
-  const { resolvedTheme, setTheme, setResolvedTheme, setShowSettings, setIsCaptureMode } =
+  const { resolvedTheme, setTheme, setResolvedTheme, setShowSettings, setIsCaptureMode, isCaptureMode } =
     useUIStore();
   const { mode, delay, setMode, setDelay } = useCaptureStore();
   const {
     isRecording,
-    setIsSelectingRegion,
-    checkFfmpeg,
-    saveWindowState,
+    stopRecording,
     webcamEnabled,
     setWebcamEnabled,
     // System audio is deferred to a future release — see SYS button TODO below.
-    // Store fields `systemAudioEnabled`, `setSystemAudioEnabled`, `hasSystemAudioCapture`
-    // remain available; re-destructure them when re-enabling the feature.
     micAudioEnabled,
     setMicAudioEnabled,
     hasMicrophone,
   } = useRecordingStore();
+  const record = useRecordFlow();
+  const isInstallingFfmpeg = record.isInstallingFfmpeg;
+  const handleRecordClick = record.onClick;
+
+  const [blockedModal, setBlockedModal] = useState<"camera" | "microphone" | null>(null);
+  const cameraPermission = useMediaPermission("camera");
+  const microphonePermission = useMediaPermission("microphone");
+  const cameraBlocked = cameraPermission === "denied";
+  const microphoneBlocked = microphonePermission === "denied";
+
+  // Native pill-menu events arrive via Tauri emit. Listen here so the same
+  // Mode/Delay dropdowns work in full mode exactly like in pill mode.
+  const handlersRef = useRef({
+    setMode,
+    setDelay,
+    setMicAudioEnabled,
+    setWebcamEnabled,
+    setBlockedModal,
+    microphonePermission,
+    cameraPermission,
+  });
+  handlersRef.current = {
+    setMode,
+    setDelay,
+    setMicAudioEnabled,
+    setWebcamEnabled,
+    setBlockedModal,
+    microphonePermission,
+    cameraPermission,
+  };
+
+  useEffect(() => {
+    const unlistenPromise = listen<string>("pill-menu-selected", (event) => {
+      const id = event.payload;
+      const h = handlersRef.current;
+      if (id.startsWith("pill-mode:")) {
+        h.setMode(id.substring("pill-mode:".length) as CaptureMode);
+      } else if (id.startsWith("pill-delay:")) {
+        const n = parseInt(id.substring("pill-delay:".length), 10);
+        h.setDelay(n as DelayOption);
+      } else if (id === "pill-opts:mic") {
+        const currentlyOn = useRecordingStore.getState().micAudioEnabled;
+        if (!currentlyOn && h.microphonePermission === "denied") {
+          h.setBlockedModal("microphone");
+        } else {
+          h.setMicAudioEnabled(!currentlyOn);
+        }
+      } else if (id === "pill-opts:webcam") {
+        const currentlyOn = useRecordingStore.getState().webcamEnabled;
+        if (!currentlyOn && h.cameraPermission === "denied") {
+          h.setBlockedModal("camera");
+        } else {
+          h.setWebcamEnabled(!currentlyOn);
+        }
+      } else if (id === "pill-opts:prefs") {
+        useUIStore.getState().setShowSettings(true);
+      }
+    });
+    return () => {
+      unlistenPromise.then((fn) => fn());
+    };
+  }, []);
+
+  const showPillMenu = (kind: "mode" | "delay", btn: HTMLElement) => {
+    const rect = btn.getBoundingClientRect();
+    invoke("show_pill_menu", {
+      kind,
+      x: rect.left,
+      y: rect.bottom + 2,
+      currentMode: mode,
+      currentDelay: delay,
+      micEnabled: micAudioEnabled,
+      webcamEnabled,
+    }).catch((e) => console.error("show_pill_menu failed:", e));
+  };
 
   const toggleTheme = () => {
     const next = resolvedTheme === "light" ? "dark" : "light";
@@ -136,74 +166,15 @@ export function TitleBar() {
   };
 
   const handleNewCapture = () => {
+    if (isCaptureMode || isRecording) return;
     setIsCaptureMode(true);
   };
 
-  const [isInstallingFfmpeg, setIsInstallingFfmpeg] = useState(false);
-  const [blockedModal, setBlockedModal] = useState<
-    "camera" | "microphone" | null
-  >(null);
-  const cameraPermission = useMediaPermission("camera");
-  const microphonePermission = useMediaPermission("microphone");
-  const cameraBlocked = cameraPermission === "denied";
-  const microphoneBlocked = microphonePermission === "denied";
-
-  // Check webcam availability and fall back gracefully if the user's camera
-  // permission is off. Called after FFmpeg is confirmed present.
-  const proceedToRecordFlow = async () => {
-    if (webcamEnabled) {
-      try {
-        const { invoke } = await import("@tauri-apps/api/core");
-        const webcams = await invoke<string[]>("list_webcams");
-        if (webcams.length === 0) {
-          alert(
-            "No webcam detected.\n\n" +
-            "If you have a camera, make sure:\n" +
-            "1. Go to Windows Settings > Privacy > Camera\n" +
-            "2. Turn ON 'Allow desktop apps to access your camera'\n\n" +
-            "Recording will continue without webcam."
-          );
-          setWebcamEnabled(false);
-        }
-      } catch {
-        setWebcamEnabled(false);
-      }
-    }
-    await saveWindowState();
-    setIsSelectingRegion(true);
+  const cancelActive = isCaptureMode || isRecording;
+  const handleCancel = () => {
+    if (isRecording) stopRecording();
+    else if (isCaptureMode) setIsCaptureMode(false);
   };
-
-  const handleRecordClick = async () => {
-    if (isRecording || isInstallingFfmpeg) return;
-    const hasFfmpeg = await checkFfmpeg();
-    if (!hasFfmpeg) {
-      const shouldDownload = confirm(
-        "Screen recording requires FFmpeg (a free, open-source video encoder).\n\n" +
-        "Klipp will download it automatically (one-time only, ~30MB).\n" +
-        "This may take a minute depending on your internet speed.\n\n" +
-        "When the install finishes, Klipp will continue to the region selector."
-      );
-      if (!shouldDownload) return;
-      setIsInstallingFfmpeg(true);
-      try {
-        const { invoke } = await import("@tauri-apps/api/core");
-        await invoke("download_ffmpeg");
-      } catch (e) {
-        setIsInstallingFfmpeg(false);
-        alert(
-          `Failed to download FFmpeg: ${e}\n\n` +
-          "You can install it manually via:\n  winget install Gyan.FFmpeg"
-        );
-        return;
-      }
-      setIsInstallingFfmpeg(false);
-      // Auto-proceed so the user's original intent (start recording) completes
-      // without a second click.
-    }
-    await proceedToRecordFlow();
-  };
-
-  const currentModeInfo = CAPTURE_MODES.find((m) => m.mode === mode) || CAPTURE_MODES[0];
 
   return (
     <div
@@ -215,108 +186,111 @@ export function TitleBar() {
         padding: "0 12px",
         backgroundColor: "var(--bg-toolbar)",
         borderBottom: "1px solid var(--border-color)",
-        height: 36,
+        height: 38,
       }}
     >
+      {/* App name */}
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
         <span style={{ fontSize: 13, fontWeight: 600 }}>{APP_NAME}</span>
       </div>
 
-      {/* Capture controls */}
+      {/* Standard navs — same sequence as pill: New → Mode → Delay → Record → Cancel */}
       <div style={{ display: "flex", alignItems: "center", gap: 2 }}>
-        {/* Capture mode selector */}
-        <DropdownButton label="Capture Mode" icon={currentModeInfo.icon}>
-          {CAPTURE_MODES.map((m) => (
-            <button
-              key={m.mode}
-              onClick={() => !m.disabled && setMode(m.mode)}
-              disabled={m.disabled}
-              title={m.disabled ? m.disabledReason : undefined}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 8,
-                width: "100%",
-                padding: "6px 8px",
-                borderRadius: 4,
-                border: "none",
-                cursor: m.disabled ? "not-allowed" : "pointer",
-                backgroundColor:
-                  mode === m.mode && !m.disabled
-                    ? "var(--accent-color)"
-                    : "transparent",
-                color: m.disabled
-                  ? "var(--text-tertiary, #999)"
-                  : mode === m.mode
-                  ? "#fff"
-                  : "var(--text-primary)",
-                fontSize: 12,
-                textAlign: "left",
-                opacity: m.disabled ? 0.55 : 1,
-              }}
-            >
-              {m.icon}
-              {m.label}
-            </button>
-          ))}
-        </DropdownButton>
-
-        {/* Delay selector */}
-        <DropdownButton
-          label="Capture Delay"
-          icon={
-            <div style={{ display: "flex", alignItems: "center", gap: 2 }}>
-              <Timer size={14} />
-              {delay > 0 && (
-                <span style={{ fontSize: 10, fontWeight: 600 }}>{delay}s</span>
-              )}
-            </div>
-          }
-        >
-          {DELAY_OPTIONS.map((d) => (
-            <button
-              key={d.value}
-              onClick={() => setDelay(d.value)}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 8,
-                width: "100%",
-                padding: "6px 8px",
-                borderRadius: 4,
-                border: "none",
-                cursor: "pointer",
-                backgroundColor: delay === d.value ? "var(--accent-color)" : "transparent",
-                color: delay === d.value ? "#fff" : "var(--text-primary)",
-                fontSize: 12,
-                textAlign: "left",
-              }}
-            >
-              {d.label}
-            </button>
-          ))}
-        </DropdownButton>
-
-        {/* Capture button */}
+        {/* ✂ New */}
         <button
-          title="New Capture"
+          title="New Capture (Ctrl+Shift+S)"
           onClick={handleNewCapture}
+          disabled={isCaptureMode || isRecording}
           style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            width: 30,
-            height: 30,
-            borderRadius: 6,
-            border: "none",
-            cursor: "pointer",
-            backgroundColor: "transparent",
-            color: "var(--text-primary)",
+            ...NAV_BTN,
+            color: isCaptureMode || isRecording ? "var(--text-secondary)" : "#dc2626",
+            fontWeight: 600,
           }}
         >
-          <Camera size={16} />
+          <Scissors size={16} />
+          <span>New</span>
         </button>
 
+        {/* ▾ Mode */}
+        <button
+          title="Mode"
+          onClick={(e) => showPillMenu("mode", e.currentTarget)}
+          style={NAV_BTN}
+        >
+          {CAPTURE_MODE_ICONS[mode]}
+          <span>Mode</span>
+          <ChevronDown size={12} />
+        </button>
+
+        {/* ⏱ Delay */}
+        <button
+          title="Delay"
+          onClick={(e) => showPillMenu("delay", e.currentTarget)}
+          style={NAV_BTN}
+        >
+          <Clock size={14} />
+          <span>{DELAY_LABELS[delay] ?? "Delay"}</span>
+          <ChevronDown size={12} />
+        </button>
+
+        {/* ⏺ Record */}
+        <button
+          title={
+            isInstallingFfmpeg
+              ? "Installing FFmpeg... (one-time ~30MB download)"
+              : isRecording
+              ? "Recording..."
+              : "Screen Record"
+          }
+          onClick={handleRecordClick}
+          disabled={isInstallingFfmpeg || isCaptureMode}
+          style={{
+            ...NAV_BTN,
+            color: isRecording
+              ? "#FF3B30"
+              : isInstallingFfmpeg
+              ? "#f59e0b"
+              : "var(--text-primary)",
+            backgroundColor: isRecording
+              ? "rgba(255,59,48,0.1)"
+              : isInstallingFfmpeg
+              ? "rgba(251,191,36,0.1)"
+              : "transparent",
+            cursor: isRecording
+              ? "default"
+              : isInstallingFfmpeg
+              ? "wait"
+              : "pointer",
+          }}
+        >
+          {isInstallingFfmpeg ? (
+            <Loader2 size={14} style={{ animation: "klipp-spin 1s linear infinite" }} />
+          ) : (
+            <Video size={14} />
+          )}
+          <span>Record</span>
+        </button>
+        <style>{`@keyframes klipp-spin { to { transform: rotate(360deg); } }`}</style>
+
+        {/* ✕ Cancel */}
+        <button
+          title={cancelActive ? "Cancel" : "Nothing to cancel"}
+          onClick={handleCancel}
+          disabled={!cancelActive}
+          style={{
+            ...NAV_BTN,
+            color: cancelActive ? "var(--text-primary)" : "var(--text-secondary)",
+            cursor: cancelActive ? "pointer" : "default",
+            opacity: cancelActive ? 1 : 0.5,
+          }}
+        >
+          <X size={14} />
+          <span>Cancel</span>
+        </button>
+      </div>
+
+      {/* Window-mode extras — placed after the standard navs */}
+      <div style={{ display: "flex", alignItems: "center", gap: 2 }}>
         {/* Webcam toggle */}
         <button
           title={
@@ -334,14 +308,7 @@ export function TitleBar() {
             setWebcamEnabled(!webcamEnabled);
           }}
           style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            width: 30,
-            height: 30,
-            borderRadius: 6,
-            border: "none",
-            cursor: "pointer",
+            ...ICON_BTN,
             backgroundColor: cameraBlocked
               ? "rgba(245, 158, 11, 0.15)"
               : webcamEnabled
@@ -354,6 +321,7 @@ export function TitleBar() {
               : "var(--text-secondary)",
             fontSize: 11,
             fontWeight: 600,
+            width: 36,
           }}
         >
           CAM
@@ -362,79 +330,63 @@ export function TitleBar() {
         {/* System audio toggle — deferred to a future release.
             TODO(next release): re-enable once we implement system-audio capture
             without requiring the third-party "virtual-audio-capturer" DirectShow
-            driver (e.g. via native WASAPI loopback). See Plan 03 doc. The state,
-            store fields (hasSystemAudioCapture, systemAudioEnabled) and Rust
-            backend support are already wired — just remove this override. */}
+            driver (e.g. via native WASAPI loopback). See Plan 03 doc. */}
         <button
           title="System Audio — coming in a future release"
           onClick={() => { /* intentionally disabled until next release */ }}
           disabled
           style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            width: 30,
-            height: 30,
-            borderRadius: 6,
-            border: "none",
-            cursor: "not-allowed",
-            backgroundColor: "transparent",
-            color: "var(--text-tertiary, #999)",
+            ...ICON_BTN,
+            color: "var(--text-secondary)",
             fontSize: 11,
             fontWeight: 600,
+            width: 36,
+            cursor: "not-allowed",
             opacity: 0.5,
           }}
         >
           SYS
         </button>
 
-        {/* Microphone toggle — disabled if no audio input device exists,
-            amber + recovery modal if WebView2 mic permission is denied. */}
+        {/* Microphone toggle */}
         <button
           title={
-            !hasMicrophone
-              ? "No microphone detected"
-              : microphoneBlocked
+            microphoneBlocked
               ? "Microphone blocked — click for help re-enabling"
+              : !hasMicrophone
+              ? "No microphone detected"
               : micAudioEnabled
               ? "Microphone: ON"
               : "Microphone: OFF"
           }
           onClick={() => {
-            if (!hasMicrophone) return;
             if (microphoneBlocked) {
               setBlockedModal("microphone");
               return;
             }
+            if (!hasMicrophone) return;
             setMicAudioEnabled(!micAudioEnabled);
           }}
-          disabled={!hasMicrophone}
+          disabled={!hasMicrophone && !microphoneBlocked}
           style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            width: 30,
-            height: 30,
-            borderRadius: 6,
-            border: "none",
-            cursor: hasMicrophone ? "pointer" : "not-allowed",
-            backgroundColor: !hasMicrophone
-              ? "transparent"
-              : microphoneBlocked
+            ...ICON_BTN,
+            backgroundColor: microphoneBlocked
               ? "rgba(245, 158, 11, 0.15)"
               : micAudioEnabled
               ? "rgba(0,120,212,0.15)"
               : "transparent",
-            color: !hasMicrophone
-              ? "var(--text-tertiary, #999)"
-              : microphoneBlocked
+            color: microphoneBlocked
               ? "#f59e0b"
+              : !hasMicrophone
+              ? "var(--text-secondary)"
               : micAudioEnabled
               ? "var(--accent-color)"
               : "var(--text-secondary)",
+            opacity: !hasMicrophone && !microphoneBlocked ? 0.4 : 1,
+            cursor: !hasMicrophone && !microphoneBlocked ? "not-allowed" : "pointer",
             fontSize: 11,
             fontWeight: 600,
-            opacity: hasMicrophone ? 1 : 0.5,
+            width: 36,
           }}
         >
           MIC
@@ -445,93 +397,25 @@ export function TitleBar() {
           <AudioLevelIndicator active={micAudioEnabled} width={44} height={20} />
         )}
 
-        {/* Record button */}
-        <button
-          title={
-            isInstallingFfmpeg
-              ? "Installing FFmpeg... (one-time ~30MB download)"
-              : isRecording
-              ? "Recording..."
-              : "Screen Record"
-          }
-          onClick={handleRecordClick}
-          disabled={isInstallingFfmpeg}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            width: 30,
-            height: 30,
-            borderRadius: 6,
-            border: "none",
-            cursor: isRecording
-              ? "default"
-              : isInstallingFfmpeg
-              ? "wait"
-              : "pointer",
-            backgroundColor: isRecording
-              ? "rgba(255,59,48,0.15)"
-              : isInstallingFfmpeg
-              ? "rgba(251, 191, 36, 0.15)"
-              : "transparent",
-            color: isRecording
-              ? "#FF3B30"
-              : isInstallingFfmpeg
-              ? "#f59e0b"
-              : "var(--text-primary)",
-          }}
-        >
-          {isInstallingFfmpeg ? (
-            <Loader2
-              size={16}
-              style={{ animation: "klipp-spin 1s linear infinite" }}
-            />
-          ) : (
-            <Video size={16} />
-          )}
-        </button>
-        <style>{`@keyframes klipp-spin { to { transform: rotate(360deg); } }`}</style>
-
-        <div style={{ width: 1, height: 20, backgroundColor: "var(--border-color)", margin: "0 2px" }} />
+        <div style={{ width: 1, height: 20, backgroundColor: "var(--border-color)", margin: "0 4px" }} />
 
         {/* Theme toggle */}
-        <button
-          title="Toggle Theme"
-          onClick={toggleTheme}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            width: 30,
-            height: 30,
-            borderRadius: 6,
-            border: "none",
-            cursor: "pointer",
-            backgroundColor: "transparent",
-            color: "var(--text-primary)",
-          }}
-        >
+        <button title="Toggle Theme" onClick={toggleTheme} style={ICON_BTN}>
           {resolvedTheme === "light" ? <Moon size={16} /> : <Sun size={16} />}
         </button>
 
         {/* Settings */}
-        <button
-          title="Settings"
-          onClick={() => setShowSettings(true)}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            width: 30,
-            height: 30,
-            borderRadius: 6,
-            border: "none",
-            cursor: "pointer",
-            backgroundColor: "transparent",
-            color: "var(--text-primary)",
-          }}
-        >
+        <button title="Settings" onClick={() => setShowSettings(true)} style={ICON_BTN}>
           <Settings size={16} />
+        </button>
+
+        {/* Collapse to pill */}
+        <button
+          title="Collapse to compact pill"
+          onClick={() => useWindowModeStore.getState().collapseToPill()}
+          style={ICON_BTN}
+        >
+          <Minimize2 size={16} />
         </button>
       </div>
 

--- a/src/hooks/useRecordFlow.ts
+++ b/src/hooks/useRecordFlow.ts
@@ -1,0 +1,72 @@
+import { useState, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useRecordingStore } from "../stores/recordingStore";
+
+/**
+ * Shared record-flow hook used by the TitleBar (full mode) and the PillModeBar.
+ * Centralises the FFmpeg-presence check, one-time download-with-spinner flow,
+ * webcam availability fallback, and transition to the region selector. Both
+ * callers get the same behaviour without duplicating the ~40-line handler.
+ */
+export function useRecordFlow() {
+  const [isInstallingFfmpeg, setIsInstallingFfmpeg] = useState(false);
+  const {
+    isRecording,
+    checkFfmpeg,
+    saveWindowState,
+    setIsSelectingRegion,
+    webcamEnabled,
+    setWebcamEnabled,
+  } = useRecordingStore();
+
+  const proceedToRecordFlow = useCallback(async () => {
+    if (webcamEnabled) {
+      try {
+        const webcams = await invoke<string[]>("list_webcams");
+        if (webcams.length === 0) {
+          alert(
+            "No webcam detected.\n\n" +
+              "If you have a camera, make sure:\n" +
+              "1. Go to Windows Settings > Privacy > Camera\n" +
+              "2. Turn ON 'Allow desktop apps to access your camera'\n\n" +
+              "Recording will continue without webcam."
+          );
+          setWebcamEnabled(false);
+        }
+      } catch {
+        setWebcamEnabled(false);
+      }
+    }
+    await saveWindowState();
+    setIsSelectingRegion(true);
+  }, [webcamEnabled, setWebcamEnabled, saveWindowState, setIsSelectingRegion]);
+
+  const onClick = useCallback(async () => {
+    if (isRecording || isInstallingFfmpeg) return;
+    const hasFfmpeg = await checkFfmpeg();
+    if (!hasFfmpeg) {
+      const shouldDownload = confirm(
+        "Screen recording requires FFmpeg (a free, open-source video encoder).\n\n" +
+          "Klipp will download it automatically (one-time only, ~30MB).\n" +
+          "This may take a minute depending on your internet speed.\n\n" +
+          "When the install finishes, Klipp will continue to the region selector."
+      );
+      if (!shouldDownload) return;
+      setIsInstallingFfmpeg(true);
+      try {
+        await invoke("download_ffmpeg");
+      } catch (e) {
+        setIsInstallingFfmpeg(false);
+        alert(
+          `Failed to download FFmpeg: ${e}\n\n` +
+            "You can install it manually via:\n  winget install Gyan.FFmpeg"
+        );
+        return;
+      }
+      setIsInstallingFfmpeg(false);
+    }
+    await proceedToRecordFlow();
+  }, [isRecording, isInstallingFfmpeg, checkFfmpeg, proceedToRecordFlow]);
+
+  return { onClick, isInstallingFfmpeg, isRecording };
+}

--- a/src/stores/windowModeStore.ts
+++ b/src/stores/windowModeStore.ts
@@ -1,0 +1,133 @@
+import { create } from "zustand";
+import { getCurrentWindow, LogicalSize, LogicalPosition } from "@tauri-apps/api/window";
+import { useSettingsStore } from "./settingsStore";
+import type { LaunchMode, WindowBounds } from "../types/settings";
+
+const PILL_DEFAULT: WindowBounds = { x: 0, y: 10, width: 560, height: 90 };
+const FULL_DEFAULT: WindowBounds = { x: 100, y: 100, width: 1200, height: 800 };
+
+// Vertical chrome stacked above/below the annotation canvas when in "full"
+// mode: TitleBar (36) + Toolbar (36) + ToolOptionsBar (36) + StatusBar (24) +
+// an OS-chrome safety buffer. Tuned so a captured region appears at native
+// size inside the canvas without getting cropped.
+const FULL_MODE_CHROME_HEIGHT = 170;
+const POST_CAPTURE_MIN_WIDTH = 560;
+const POST_CAPTURE_MIN_HEIGHT = 400;
+
+interface WindowModeState {
+  mode: LaunchMode;
+  initFromSettings: () => void;
+  expandToFull: () => Promise<void>;
+  expandToCaptureSize: (captureWidth: number, captureHeight: number) => Promise<void>;
+  collapseToPill: () => Promise<void>;
+}
+
+async function readCurrentBounds(): Promise<WindowBounds> {
+  const win = getCurrentWindow();
+  const size = await win.innerSize();
+  const pos = await win.outerPosition();
+  const scale = await win.scaleFactor();
+  return {
+    x: Math.round(pos.x / scale),
+    y: Math.round(pos.y / scale),
+    width: Math.round(size.width / scale),
+    height: Math.round(size.height / scale),
+  };
+}
+
+async function applyBounds(bounds: WindowBounds, resizable: boolean) {
+  const win = getCurrentWindow();
+  await win.setResizable(resizable);
+  await win.setSize(new LogicalSize(bounds.width, bounds.height));
+  await win.setPosition(new LogicalPosition(bounds.x, bounds.y));
+}
+
+function centeredPillBounds(): WindowBounds {
+  const w = PILL_DEFAULT.width;
+  const screenW = typeof window !== "undefined" ? window.screen.width : 1920;
+  return { ...PILL_DEFAULT, x: Math.max(0, Math.round(screenW / 2 - w / 2)) };
+}
+
+export const useWindowModeStore = create<WindowModeState>((set, get) => ({
+  mode: "pill",
+
+  initFromSettings: () => {
+    const { settings } = useSettingsStore.getState();
+    set({ mode: settings.launchMode });
+  },
+
+  expandToFull: async () => {
+    if (get().mode === "full") return;
+    const { updateSettings, settings } = useSettingsStore.getState();
+    const pillBounds = await readCurrentBounds().catch(() => null);
+    const target = settings.fullBounds ?? FULL_DEFAULT;
+    try {
+      await applyBounds(target, true);
+    } catch (e) {
+      console.error("expandToFull failed:", e);
+      return;
+    }
+    set({ mode: "full" });
+    await updateSettings({
+      launchMode: "full",
+      pillBounds: pillBounds ?? settings.pillBounds,
+    });
+  },
+
+  /**
+   * Called after a screenshot capture: resize the window to fit the captured
+   * region + annotation chrome, centered on screen. Mirrors Snipping Tool's
+   * post-capture UX — the window becomes just big enough to show the capture
+   * without obscuring the rest of the desktop. Clamped to sensible
+   * min (so toolbar fits) and max (90% of screen) bounds.
+   *
+   * Importantly, this does NOT persist `launchMode: "full"` to settings.
+   * A capture-driven expand is transient — the user's *preferred* launch
+   * state is set only by the manual ⤢ Expand / ⤡ Collapse buttons. Without
+   * this guarded behaviour, every screenshot would flip the next-launch
+   * state to "full", which is not the Snipping-Tool-like experience we want.
+   */
+  expandToCaptureSize: async (captureW, captureH) => {
+    const screenW = typeof window !== "undefined" ? window.screen.width : 1920;
+    const screenH = typeof window !== "undefined" ? window.screen.height : 1080;
+    const maxW = Math.round(screenW * 0.9);
+    const maxH = Math.round(screenH * 0.9);
+
+    const targetW = Math.max(POST_CAPTURE_MIN_WIDTH, Math.min(maxW, captureW));
+    const targetH = Math.max(
+      POST_CAPTURE_MIN_HEIGHT,
+      Math.min(maxH, captureH + FULL_MODE_CHROME_HEIGHT)
+    );
+
+    const x = Math.max(0, Math.round(screenW / 2 - targetW / 2));
+    const y = Math.max(30, Math.round(screenH / 2 - targetH / 2));
+
+    try {
+      await applyBounds({ x, y, width: targetW, height: targetH }, true);
+    } catch (e) {
+      console.error("expandToCaptureSize failed:", e);
+      return;
+    }
+    // Update in-memory mode only so App.tsx re-renders into the full layout,
+    // but leave settings.launchMode untouched (stays "pill" for next launch).
+    set({ mode: "full" });
+  },
+
+  collapseToPill: async () => {
+    if (get().mode === "pill") return;
+    const { updateSettings, settings } = useSettingsStore.getState();
+    const fullBounds = await readCurrentBounds().catch(() => null);
+    const target = settings.pillBounds ?? centeredPillBounds();
+    try {
+      await applyBounds(target, false);
+    } catch (e) {
+      console.error("collapseToPill failed:", e);
+      return;
+    }
+    set({ mode: "pill" });
+    await updateSettings({
+      launchMode: "pill",
+      fullBounds: fullBounds ?? settings.fullBounds,
+    });
+  },
+}));

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,5 +1,14 @@
 export type Theme = "light" | "dark" | "system";
 
+export type LaunchMode = "pill" | "full";
+
+export interface WindowBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 export interface AppSettings {
   theme: Theme;
   autoCopyToClipboard: boolean;
@@ -9,6 +18,9 @@ export interface AppSettings {
   captureShortcut: string;
   snipOutline: boolean;
   snipOutlineColor: string;
+  launchMode: LaunchMode;
+  pillBounds: WindowBounds | null;
+  fullBounds: WindowBounds | null;
 }
 
 export const DEFAULT_SETTINGS: AppSettings = {
@@ -20,4 +32,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   captureShortcut: "Ctrl+Shift+S",
   snipOutline: false,
   snipOutlineColor: "#FF0000",
+  launchMode: "pill",
+  pillBounds: null,
+  fullBounds: null,
 };


### PR DESCRIPTION
## Summary

Implements [Plan 12](docs/plans/12-compact-pill-launch-mode.md) — Klipp now launches as a compact 560×90 pill (Snipping Tool style) instead of an 800×600 full window, so the initial state doesn't obstruct the content the user wants to capture. After a Snip, the window resizes to fit the captured region. Mode and bounds persist across launches.

## Behaviour highlights

- **Two-row pill** (~560×90): action bar (`✂ New → ▾ Mode → ⏱ Delay → ⏺ Record → ✕ Cancel … ⋯ Options ⤢ Expand`) + context-aware helper text underneath.
- **Native OS popup menus** for Mode / Delay / Options via a new \`show_pill_menu\` Tauri command. The menu paints **outside the pill window** the way Snipping Tool does — no window-resize hack, no DOM dropdown clipping.
- **Auto-expand to fit captured region** after a Snip (mirrors Snipping Tool). Window is sized to \`max(560, captureW) × max(400, captureH + chrome)\`, clamped to 90% of screen, centred. *Important*: auto-expand does **not** persist \`launchMode: full\` — only the manual ⤢ Expand / ⤡ Collapse buttons mutate the user's preferred launch state, so the next launch still starts as a pill.
- **TitleBar nav re-ordered** to match the pill sequence (New → Mode → Delay → Record → Cancel) for cross-mode consistency. CAM / SYS / MIC / AudioLevel / Theme / Settings / Collapse are appended after the standard navs.
- **\`✂ New\` is now a labelled button** (Scissors icon + \"New\" + accent red) in both navs, replacing the earlier icon-only Camera button which read as inaccessible (\"only the Ctrl+Shift+S hotkey worked\").

## Files

**New (4):**
- \`src-tauri/src/commands/pill_menu.rs\` — \`show_pill_menu\` command + Mode / Delay / Options menu builders. Routed via global \`on_menu_event\` → \`pill-menu-selected\` event.
- \`src/stores/windowModeStore.ts\` — pill ↔ full state machine (\`expandToFull\`, \`expandToCaptureSize\`, \`collapseToPill\`).
- \`src/hooks/useRecordFlow.ts\` — extracted FFmpeg-check / download-with-spinner record handler shared between TitleBar and PillModeBar.
- \`src/components/layout/PillModeBar.tsx\` — pill UI.

**Modified (11):**
- \`src-tauri/tauri.conf.json\`, \`src-tauri/src/lib.rs\`, \`src-tauri/src/commands/{settings.rs,mod.rs}\`, \`src-tauri/capabilities/default.json\` (granted \`core:window:allow-set-resizable\`)
- \`src/App.tsx\` (conditional render), \`src/components/capture/CaptureOverlay.tsx\` (auto-expand on capture), \`src/components/layout/TitleBar.tsx\` (re-ordered nav, native menus), \`src/types/settings.ts\` (added LaunchMode + WindowBounds)
- \`docs/plans/12-compact-pill-launch-mode.md\` (marked shipped + noted divergences), \`docs/plans/STATUS.md\` (8 shipped · 4 pending)

## Verification

- ✅ \`npx tsc --noEmit\` clean
- ✅ \`cargo check\` clean (only the pre-existing \`next_input_idx\` warning)
- ✅ Manual smoke test in dev: fresh launch → pill at top-centre → Mode/Delay native popups paint outside the pill → Snip → window resizes to fit region → Collapse → re-launch starts as pill again

## Known follow-ups (out of scope here)

- Permission-blocked modal for Microphone / Webcam in the Options popover currently fires from the React listener, not from the menu itself — works, but a slightly more native flow would route the block info through Rust.
- Window-mode \`Options\` button isn't surfaced in the new TitleBar (CAM/MIC/SYS/Settings are already first-class buttons there) — intentional, but mention here for transparency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)