### PR TITLE
polish: Klipp-branded FFmpeg install modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { EmojiPicker } from "./components/canvas/EmojiPicker";
 import { RecordingControls } from "./components/recording/RecordingControls";
 import { RecordingRegionSelector } from "./components/recording/RecordingRegionSelector";
 import { DeviceConsentGate } from "./components/recording/DeviceConsentGate";
+import { FfmpegInstallModal } from "./components/recording/FfmpegInstallModal";
 import { useUIStore } from "./stores/uiStore";
 import { useCaptureStore } from "./stores/captureStore";
 import { useCanvasStore } from "./stores/canvasStore";
@@ -186,6 +187,7 @@ function App() {
         />
       )}
       <DeviceConsentGate />
+      <FfmpegInstallModal />
     </div>
   );
 }

--- a/src/components/recording/FfmpegInstallModal.tsx
+++ b/src/components/recording/FfmpegInstallModal.tsx
@@ -1,0 +1,208 @@
+import { Download, AlertTriangle, X } from "lucide-react";
+import { useFfmpegStore } from "../../stores/ffmpegStore";
+import { APP_NAME } from "../../lib/constants";
+
+/**
+ * Klipp-branded modal shown when a recording attempt needs FFmpeg installed.
+ * Replaces the unbranded `confirm()` / `alert()` dialogs that the previous
+ * minimal-fix flow used.
+ *
+ * Renders two states driven by `useFfmpegStore`:
+ *   - "prompt": first-run explanation + Install / Not now
+ *   - "error":  install failed, shows message + `winget` fallback + Try again
+ *
+ * During the download itself the modal is closed and the Record button shows
+ * its existing amber spinner state (isInstalling).
+ */
+export function FfmpegInstallModal() {
+  const modal = useFfmpegStore((s) => s.modal);
+  const errorMessage = useFfmpegStore((s) => s.errorMessage);
+  const confirmInstall = useFfmpegStore((s) => s.confirmInstall);
+  const retryInstall = useFfmpegStore((s) => s.retryInstall);
+  const cancel = useFfmpegStore((s) => s.cancel);
+
+  if (modal === null) return null;
+
+  const isPrompt = modal === "prompt";
+
+  return (
+    <div
+      onClick={cancel}
+      style={{
+        position: "fixed",
+        inset: 0,
+        backgroundColor: "rgba(0, 0, 0, 0.5)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 10000,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ffmpeg-install-title"
+        style={{
+          backgroundColor: "var(--bg-primary)",
+          color: "var(--text-primary)",
+          borderRadius: 10,
+          padding: 22,
+          maxWidth: 460,
+          width: "90%",
+          boxShadow: "0 12px 40px rgba(0,0,0,0.35)",
+          position: "relative",
+        }}
+      >
+        <button
+          onClick={cancel}
+          aria-label="Close"
+          style={{
+            position: "absolute",
+            top: 10,
+            right: 10,
+            background: "transparent",
+            border: "none",
+            cursor: "pointer",
+            color: "var(--text-secondary)",
+            padding: 4,
+            display: "flex",
+          }}
+        >
+          <X size={16} />
+        </button>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            marginBottom: 12,
+          }}
+        >
+          <div
+            style={{
+              width: 44,
+              height: 44,
+              borderRadius: 10,
+              backgroundColor: isPrompt
+                ? "rgba(0, 120, 212, 0.12)"
+                : "rgba(220, 38, 38, 0.12)",
+              color: isPrompt ? "var(--accent-color)" : "#dc2626",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexShrink: 0,
+            }}
+          >
+            {isPrompt ? <Download size={24} /> : <AlertTriangle size={24} />}
+          </div>
+          <h2
+            id="ffmpeg-install-title"
+            style={{
+              fontSize: 15,
+              fontWeight: 600,
+              margin: 0,
+              lineHeight: 1.3,
+            }}
+          >
+            {isPrompt
+              ? `${APP_NAME} needs FFmpeg to record your screen`
+              : `${APP_NAME} couldn't install FFmpeg`}
+          </h2>
+        </div>
+
+        {isPrompt ? (
+          <>
+            <p style={{ fontSize: 13, lineHeight: 1.55, margin: "0 0 8px" }}>
+              FFmpeg is a free, open-source video encoder that powers screen
+              recording. {APP_NAME} will download it automatically — a one-time
+              install, about 30&nbsp;MB.
+            </p>
+            <p
+              style={{
+                fontSize: 12,
+                lineHeight: 1.5,
+                margin: "0 0 18px",
+                color: "var(--text-secondary)",
+              }}
+            >
+              This may take up to a minute. Once it's done, {APP_NAME} will
+              continue to the region selector automatically.
+            </p>
+          </>
+        ) : (
+          <>
+            <p style={{ fontSize: 13, lineHeight: 1.55, margin: "0 0 10px" }}>
+              {errorMessage ??
+                "The download didn't complete. Check your internet connection and try again."}
+            </p>
+            <p
+              style={{
+                fontSize: 12,
+                lineHeight: 1.5,
+                margin: "0 0 6px",
+                color: "var(--text-secondary)",
+              }}
+            >
+              Still stuck? You can install it manually with:
+            </p>
+            <div
+              style={{
+                fontFamily: "monospace",
+                fontSize: 12,
+                backgroundColor: "var(--bg-secondary, rgba(0,0,0,0.05))",
+                padding: "6px 8px",
+                borderRadius: 4,
+                margin: "0 0 18px",
+                overflowX: "auto",
+                whiteSpace: "nowrap",
+              }}
+            >
+              winget install Gyan.FFmpeg
+            </div>
+          </>
+        )}
+
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            gap: 8,
+          }}
+        >
+          <button
+            onClick={cancel}
+            style={{
+              padding: "7px 14px",
+              borderRadius: 6,
+              border: "1px solid var(--border-color)",
+              backgroundColor: "transparent",
+              color: "var(--text-primary)",
+              cursor: "pointer",
+              fontSize: 13,
+            }}
+          >
+            {isPrompt ? "Not now" : "Dismiss"}
+          </button>
+          <button
+            onClick={isPrompt ? confirmInstall : retryInstall}
+            autoFocus
+            style={{
+              padding: "7px 16px",
+              borderRadius: 6,
+              border: "1px solid var(--accent-color)",
+              backgroundColor: "var(--accent-color)",
+              color: "#fff",
+              cursor: "pointer",
+              fontSize: 13,
+              fontWeight: 600,
+            }}
+          >
+            {isPrompt ? "Install FFmpeg" : "Try again"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useRecordFlow.ts
+++ b/src/hooks/useRecordFlow.ts
@@ -1,15 +1,21 @@
-import { useState, useCallback } from "react";
+import { useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useRecordingStore } from "../stores/recordingStore";
+import { useFfmpegStore } from "../stores/ffmpegStore";
+import { useWindowModeStore } from "../stores/windowModeStore";
 
 /**
  * Shared record-flow hook used by the TitleBar (full mode) and the PillModeBar.
- * Centralises the FFmpeg-presence check, one-time download-with-spinner flow,
- * webcam availability fallback, and transition to the region selector. Both
- * callers get the same behaviour without duplicating the ~40-line handler.
+ * Handles the FFmpeg-presence check, routes missing-FFmpeg cases through the
+ * Klipp-branded install modal, falls back to a friendly webcam-missing prompt,
+ * and transitions to the region selector. Both callers get the same behaviour
+ * without duplicating the handler.
+ *
+ * Install-modal state lives in `useFfmpegStore` (not here), so the post-install
+ * `proceedToRecordFlow` callback survives the pill → full window-mode remount
+ * that happens when we `expandToFull()` to make room for the modal.
  */
 export function useRecordFlow() {
-  const [isInstallingFfmpeg, setIsInstallingFfmpeg] = useState(false);
   const {
     isRecording,
     checkFfmpeg,
@@ -18,6 +24,7 @@ export function useRecordFlow() {
     webcamEnabled,
     setWebcamEnabled,
   } = useRecordingStore();
+  const isInstallingFfmpeg = useFfmpegStore((s) => s.isInstalling);
 
   const proceedToRecordFlow = useCallback(async () => {
     if (webcamEnabled) {
@@ -44,28 +51,19 @@ export function useRecordFlow() {
   const onClick = useCallback(async () => {
     if (isRecording || isInstallingFfmpeg) return;
     const hasFfmpeg = await checkFfmpeg();
-    if (!hasFfmpeg) {
-      const shouldDownload = confirm(
-        "Screen recording requires FFmpeg (a free, open-source video encoder).\n\n" +
-          "Klipp will download it automatically (one-time only, ~30MB).\n" +
-          "This may take a minute depending on your internet speed.\n\n" +
-          "When the install finishes, Klipp will continue to the region selector."
-      );
-      if (!shouldDownload) return;
-      setIsInstallingFfmpeg(true);
-      try {
-        await invoke("download_ffmpeg");
-      } catch (e) {
-        setIsInstallingFfmpeg(false);
-        alert(
-          `Failed to download FFmpeg: ${e}\n\n` +
-            "You can install it manually via:\n  winget install Gyan.FFmpeg"
-        );
-        return;
-      }
-      setIsInstallingFfmpeg(false);
+    if (hasFfmpeg) {
+      await proceedToRecordFlow();
+      return;
     }
-    await proceedToRecordFlow();
+    // In pill mode the 560x90 window clips rich React modals — expand to full
+    // so the install prompt renders readably. Matches the pattern used for
+    // the device-consent modal (see stores/consentStore).
+    if (useWindowModeStore.getState().mode === "pill") {
+      await useWindowModeStore.getState().expandToFull();
+    }
+    useFfmpegStore.getState().showPrompt(() => {
+      void proceedToRecordFlow();
+    });
   }, [isRecording, isInstallingFfmpeg, checkFfmpeg, proceedToRecordFlow]);
 
   return { onClick, isInstallingFfmpeg, isRecording };

--- a/src/stores/ffmpegStore.ts
+++ b/src/stores/ffmpegStore.ts
@@ -1,0 +1,73 @@
+import { create } from "zustand";
+import { invoke } from "@tauri-apps/api/core";
+
+type Modal = "prompt" | "error" | null;
+
+interface FfmpegState {
+  /** Which modal is currently open, if any. */
+  modal: Modal;
+  /** True while the download is in flight (button shows spinner, modal closed). */
+  isInstalling: boolean;
+  /** Last install error message, shown in the error modal. */
+  errorMessage: string | null;
+  /** Queued after a successful install — fires `proceedToRecordFlow` from useRecordFlow. */
+  pendingProceed: (() => void) | null;
+
+  /**
+   * Open the install prompt modal and remember what to do once the user
+   * grants consent to install. Lives in the store (not a component) so the
+   * callback survives the pill ↔ full window-mode remount that occurs when
+   * pill-mode Record triggers expandToFull before showing the modal.
+   */
+  showPrompt: (onReady: () => void) => void;
+
+  /** User clicked Install in the prompt. Runs the download and post-install callback. */
+  confirmInstall: () => Promise<void>;
+
+  /** User clicked Try again in the error modal. Same logic as confirmInstall. */
+  retryInstall: () => Promise<void>;
+
+  /** User dismissed either modal. Clears pending callback. */
+  cancel: () => void;
+}
+
+async function runDownload(): Promise<string | null> {
+  try {
+    await invoke("download_ffmpeg");
+    return null;
+  } catch (e) {
+    return typeof e === "string" ? e : String(e);
+  }
+}
+
+export const useFfmpegStore = create<FfmpegState>((set, get) => ({
+  modal: null,
+  isInstalling: false,
+  errorMessage: null,
+  pendingProceed: null,
+
+  showPrompt: (onReady) => {
+    set({ modal: "prompt", errorMessage: null, pendingProceed: onReady });
+  },
+
+  confirmInstall: async () => {
+    set({ modal: null, isInstalling: true, errorMessage: null });
+    const err = await runDownload();
+    if (err) {
+      set({ isInstalling: false, modal: "error", errorMessage: err });
+      return;
+    }
+    const cb = get().pendingProceed;
+    set({ isInstalling: false, pendingProceed: null });
+    cb?.();
+  },
+
+  retryInstall: async () => {
+    // Same flow as the initial confirm — the callback is still queued.
+    await get().confirmInstall();
+  },
+
+  cancel: () => {
+    set({ modal: null, pendingProceed: null, errorMessage: null });
+  },
+}));


### PR DESCRIPTION
> Stacked on #22 (Plan 11). Merge that first; this one rebases onto main automatically once it's in.

## Summary

- Replaces browser `confirm()` / `alert()` dialogs in the record flow with a Klipp-branded modal matching the Plan 11 consent-modal style.
- Install UX is otherwise unchanged — same download, same auto-proceed on success. This is pure visual polish, not a behavior change.
- Pill-mode compatible: `await expandToFull()` before opening the modal (same pattern established in Plan 11) so the rich dialog isn't clipped by the 560×90 pill.

## Architecture

- **`stores/ffmpegStore.ts`** (new) — Zustand store for modal state (`prompt` / `error` / null), `isInstalling` flag, and a `pendingProceed` callback queued across the install. Living in the store means the callback survives the pill → full remount.
- **`components/recording/FfmpegInstallModal.tsx`** (new) — two states:
  - **Prompt**: download icon, "Klipp needs FFmpeg to record your screen" explanation, 30 MB size note, Install / Not now buttons.
  - **Error**: alert icon, error message, `winget install Gyan.FFmpeg` fallback, Try again / Dismiss buttons.
  - During the download itself the modal closes; the Record button keeps its existing amber spinner.
- **`hooks/useRecordFlow.ts`** — drops `confirm()` / `alert()`, routes missing FFmpeg through `useFfmpegStore.showPrompt(onReady)`. If `windowMode === "pill"`, `await expandToFull()` before opening so the modal has room to render.
- **`App.tsx`** — mounts `<FfmpegInstallModal />` once alongside `<DeviceConsentGate />`.

## Test plan

- [ ] Fresh install (no FFmpeg, e.g. delete `%APPDATA%/com.zyntaxzo.klipp/ffmpeg/`): click Record in full mode → **Klipp-branded** install modal appears (download icon, explanation, Install / Not now)
- [ ] Click Install → modal closes, Record button shows amber spinner → download completes → Record auto-proceeds to region selector
- [ ] Click Not now → modal closes, nothing else happens
- [ ] Simulate a download failure (turn off network → click Install) → modal switches to error state with `winget` fallback and Try again button
- [ ] Try again → either succeeds or shows error again
- [ ] Pill mode: click Record while FFmpeg missing → window expands to full → install modal appears at full width (not clipped)
- [ ] After successful pill-mode install → region selector opens in the now-expanded window; user can collapse back to pill after recording
- [ ] FFmpeg already present: click Record → no modal, goes straight to region selector
- [ ] No browser `confirm()` or `alert()` dialogs appear at any point in the record flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)